### PR TITLE
decode binary for easier log information

### DIFF
--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -1,4 +1,3 @@
-import binascii
 import logging
 import socket
 import struct
@@ -69,9 +68,13 @@ class Protocol:
             ids.append(id_bytes)
             payloads.append(payload)
 
-        logger.debug(
-            f"{self.name} received {len(ids)} tasks with ids: {[int(binascii.hexlify(id),16) for id in ids]}"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "%s received %d tasks with ids: %s",
+                self.name,
+                len(ids),
+                struct.unpack("!" + "I" * len(ids), b"".join(ids)),
+            )
         return flag, ids, payloads
 
     def send(self, flag, ids, payloads):
@@ -86,11 +89,14 @@ class Protocol:
                 data.extend(task_id)
                 data.extend(length)
                 data.extend(payload)
-
         self.socket.sendall(data)
-        logger.debug(
-            f"{self.name} sent {len(ids)} tasks with ids: {[int(binascii.hexlify(id),16) for id in ids]}"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "%s sent %d tasks with ids: %s",
+                self.name,
+                len(ids),
+                struct.unpack("!" + "I" * len(ids), b"".join(ids)),
+            )
 
     def open(self):
         """Open the socket connection"""

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -1,3 +1,4 @@
+import binascii
 import logging
 import socket
 import struct
@@ -68,7 +69,9 @@ class Protocol:
             ids.append(id_bytes)
             payloads.append(payload)
 
-        logger.debug(f"{self.name} received {len(ids)} tasks with ids: {ids}")
+        logger.debug(
+            f"{self.name} received {len(ids)} tasks with ids: {[int(binascii.hexlify(id),16) for id in ids]}"
+        )
         return flag, ids, payloads
 
     def send(self, flag, ids, payloads):
@@ -85,7 +88,9 @@ class Protocol:
                 data.extend(payload)
 
         self.socket.sendall(data)
-        logger.debug(f"{self.name} sent {len(ids)} tasks with ids: {ids}")
+        logger.debug(
+            f"{self.name} sent {len(ids)} tasks with ids: {[int(binascii.hexlify(id),16) for id in ids]}"
+        )
 
     def open(self):
         """Open the socket connection"""


### PR DESCRIPTION
* Decode ids to int to aid debugging

Logs Before
```text
received 10 tasks with ids: [b'\x00\x00\x00\x00', b'\x00\x00\x00\x01', b'\x00\x00\x00\x02', b'\x00\x00\x00\x03', b'\x00\x00\x00\x04', b'\x00\x00\x00\x05', b'\x00\x00\x00\x06', b'\x00\x00\x00\x07', b'\x00\x00\x00\x08', b'\x00\x00\x00\t']
```
Logs After
```text
received 10 tasks with ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```