### PR TITLE
Make sure input and model are on the same device

### DIFF
--- a/examples/distil_bert_server_pytorch.py
+++ b/examples/distil_bert_server_pytorch.py
@@ -62,7 +62,7 @@ class Inference(Worker):
         tensors = [torch.tensor(token) for token in data]
         with torch.no_grad():
             result = self.model(
-                torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True)
+                torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True).to(self.device)
             )[0]
         scores = result.softmax(dim=1).cpu().tolist()
         return [f"positive={p}" for (_, p) in scores]

--- a/examples/distil_bert_server_pytorch.py
+++ b/examples/distil_bert_server_pytorch.py
@@ -62,7 +62,9 @@ class Inference(Worker):
         tensors = [torch.tensor(token) for token in data]
         with torch.no_grad():
             result = self.model(
-                torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True).to(self.device)
+                torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True).to(
+                    self.device
+                )
             )[0]
         scores = result.softmax(dim=1).cpu().tolist()
         return [f"positive={p}" for (_, p) in scores]


### PR DESCRIPTION
If model is on cuda device, the following lines will cause device error:

```python
with torch.no_grad():
    result = self.model(
        torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True)
    )[0]
```

The input should be converted to same device as model:

```python
torch.nn.utils.rnn.pad_sequence(tensors, batch_first=True).to(self.device)
```