### PR TITLE
update int_ge_1 validation error explanation

### DIFF
--- a/mosec/server.py
+++ b/mosec/server.py
@@ -96,7 +96,7 @@ class Server:
             assert isinstance(
                 number, int
             ), f"{name} must be integer but you give {type(number)}"
-            assert number >= 1, f"{name} must be greater than 1"
+            assert number >= 1, f"{name} must be no less than 1"
 
         def validate_env():
             if env is None:


### PR DESCRIPTION
## Validation Error Explanation Typo

In the func `validate_int_ge_1`, it's checking if the number is greater or equal to 1. 
However in the current error message, it is said `must be greater than 1`, it may confuse the user a bit.