### PR TITLE
fix: pylint no-self-use plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ changelog = "https://github.com/mosecorg/mosec/releases"
 profile = "black"
 
 [tool.pylint.master]
-load-plugins = "pylint.extensions.docparams,pylint.extensions.docstyle"
+load-plugins = "pylint.extensions.docparams,pylint.extensions.docstyle,pylint.extensions.no_self_use"
 default-docstring-type = "google"
 
 [tool.pylint.format]


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

this one has been moved to the optional extension

- https://github.com/PyCQA/pylint/pull/6448
- https://pylint.pycqa.org/en/stable/user_guide/messages/refactor/no-self-use.html?highlight=no-self-use