### PR TITLE
chore: fix dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,4 +33,4 @@ updates:
     reviewers:
       - "kemingy"
     commit-message:
-      prefix: "chore(github-actions)"
+      prefix: "chore(actions)"


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

> Dependabot encountered the following error when parsing your `.github/dependabot.yml`:
> `The property '#/updates/2/commit-message/prefix' was not of a maximum string length of 15`