### PR TITLE
feat: lint with pyright

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,6 +43,12 @@ jobs:
           pip install -r requirements/dev.txt
           rustup toolchain install nightly
           rustup component add rustfmt --toolchain nightly
+      - name: install node for pyright
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install pyright
+        run: npm install -g pyright
       - name: Lint
         run: make lint
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,11 +38,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/dev.txt
-          rustup toolchain install nightly
-          rustup component add rustfmt --toolchain nightly
+        run: make install
       - name: install node for pyright
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,11 +21,7 @@ jobs:
           python-version: 3.8
       - uses: ./.github/actions/cache
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/dev.txt
-          rustup toolchain install nightly
-          rustup component add rustfmt --toolchain nightly
+        run: make install
       - name: install node for pyright
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -26,6 +26,12 @@ jobs:
           pip install -r requirements/dev.txt
           rustup toolchain install nightly
           rustup component add rustfmt --toolchain nightly
+      - name: install node for pyright
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install pyright
+        run: npm install -g pyright
       - name: Lint
         run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ lint:
 	pylint -j 8 --recursive=y --disable=import-error examples --generated-members=numpy.*,torch.*,cv2.*,cv.*
 	pydocstyle mosec
 	@-rm mosec/_version.py
-	mypy --install-types --non-interactive ${PY_SOURCE_FILES}
+	pyright --stats
+	mypy --non-interactive --install-types ${PY_SOURCE_FILES}
 	cargo +nightly fmt -- --check
 
 semantic_lint:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PY_SOURCE_FILES=mosec tests examples scripts setup.py
 RUST_SOURCE_FILES=src/*
 
 install:
-	pip install -e .[dev,doc]
+	pip install -e .[dev,doc,plugin]
 	pre-commit install
 	rustup toolchain install nightly
 	rustup component add rustfmt --toolchain nightly

--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -21,9 +21,8 @@ import socket
 import struct
 import time
 import traceback
-from functools import partial
 from multiprocessing.synchronize import Event
-from typing import Any, Callable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Optional, Sequence, Tuple, Type
 
 from .errors import DecodingError, ValidationError
 from .ipc import IPCWrapper
@@ -60,7 +59,7 @@ class Coordinator:
         socket_prefix: str,
         stage_id: int,
         worker_id: int,
-        ipc_wrapper: Optional[Union[IPCWrapper, partial]],
+        ipc_wrapper: Optional[Callable[..., IPCWrapper]],
     ):
         """Initialize the mosec coordinator.
 
@@ -75,6 +74,9 @@ class Coordinator:
             worker_id (int): identification number for worker processes at the same
                 stage.
             ipc_wrapper (IPCWrapper): IPC wrapper class to be initialized.
+
+        Raises:
+            TypeError: ipc_wrapper should inherit from `IPCWrapper`
         """
         worker._worker_id = worker_id
         self.worker = worker()
@@ -92,12 +94,11 @@ class Coordinator:
         # optional plugin features - ipc wrapper
         self.ipc_wrapper: Optional[IPCWrapper] = None
         if ipc_wrapper is not None:
-            if not isinstance(ipc_wrapper, partial):
-                assert issubclass(
-                    ipc_wrapper, type(IPCWrapper)
-                ), "ipc_wrapper must be inherited from mosec.plugins.IPCWrapper"
-
             self.ipc_wrapper = ipc_wrapper()
+            if not issubclass(type(self.ipc_wrapper), IPCWrapper):
+                raise TypeError(
+                    "ipc_wrapper must be the subclass of mosec.plugins.IPCWrapper"
+                )
 
         # ignore termination & interruption signal
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
@@ -180,7 +181,7 @@ class Coordinator:
 
     def get_protocol_recv(
         self,
-    ) -> Callable[[], Tuple[bytes, List[bytes], List[bytes]]]:
+    ) -> Callable[[], Tuple[bytes, Sequence[bytes], Sequence[bytes]]]:
         """Get the protocol receive function for this stage.
 
         IPC wrapper will be used if it's provided and the stage is not the first one.
@@ -188,14 +189,19 @@ class Coordinator:
         if STAGE_INGRESS in self.worker.stage or self.ipc_wrapper is None:
             return self.protocol.receive
 
-        def wrapped_recv():
+        # TODO(kemingy) find a better way
+        def wrapped_recv() -> Tuple[bytes, Sequence[bytes], Sequence[bytes]]:
             flag, ids, payloads = self.protocol.receive()
-            payloads = self.ipc_wrapper.get([bytes(x) for x in payloads])
+            payloads = self.ipc_wrapper.get(  # type: ignore
+                [bytes(x) for x in payloads]
+            )
             return flag, ids, payloads
 
         return wrapped_recv
 
-    def get_protocol_send(self) -> Callable[[int, List[bytes], List[bytes]], None]:
+    def get_protocol_send(
+        self,
+    ) -> Callable[[int, Sequence[bytes], Sequence[bytes]], None]:
         """Get the protocol send function for this stage.
 
         IPC wrapper will be used if it's provided and the stage is not the last one.
@@ -203,7 +209,8 @@ class Coordinator:
         if STAGE_EGRESS in self.worker.stage or self.ipc_wrapper is None:
             return self.protocol.send
 
-        def wrapped_send(flag: int, ids: List[bytes], payloads: List[bytes]):
+        # TODO(kemingy) find a better way
+        def wrapped_send(flag: int, ids: Sequence[bytes], payloads: Sequence[bytes]):
             if flag == Protocol.FLAG_OK:
                 payloads = self.ipc_wrapper.put(payloads)  # type: ignore
             return self.protocol.send(flag, ids, payloads)

--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -23,7 +23,7 @@ import time
 import traceback
 from functools import partial
 from multiprocessing.synchronize import Event
-from typing import Any, Callable, List, Optional, Tuple, Type
+from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
 from .errors import DecodingError, ValidationError
 from .ipc import IPCWrapper
@@ -60,7 +60,7 @@ class Coordinator:
         socket_prefix: str,
         stage_id: int,
         worker_id: int,
-        ipc_wrapper: Type[IPCWrapper],
+        ipc_wrapper: Optional[Union[IPCWrapper, partial]],
     ):
         """Initialize the mosec coordinator.
 
@@ -94,7 +94,7 @@ class Coordinator:
         if ipc_wrapper is not None:
             if not isinstance(ipc_wrapper, partial):
                 assert issubclass(
-                    ipc_wrapper, IPCWrapper
+                    ipc_wrapper, type(IPCWrapper)
                 ), "ipc_wrapper must be inherited from mosec.plugins.IPCWrapper"
 
             self.ipc_wrapper = ipc_wrapper()
@@ -180,7 +180,7 @@ class Coordinator:
 
     def get_protocol_recv(
         self,
-    ) -> Callable[[], Tuple[bytes, List[bytes], List[bytearray]]]:
+    ) -> Callable[[], Tuple[bytes, List[bytes], List[bytes]]]:
         """Get the protocol receive function for this stage.
 
         IPC wrapper will be used if it's provided and the stage is not the first one.

--- a/mosec/plugins/plasma_shm.py
+++ b/mosec/plugins/plasma_shm.py
@@ -22,7 +22,7 @@ sent via the original way.
 """
 
 import warnings
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from ..ipc import IPCWrapper
 
@@ -34,6 +34,9 @@ except ImportError:
     warnings.warn(
         "pyarrow is not installed. PlasmaShmWrapper is not available.", ImportWarning
     )
+
+if TYPE_CHECKING:
+    from pyarrow import plasma
 
 
 class PlasmaShmWrapper(IPCWrapper):

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -69,7 +69,7 @@ class Protocol:
         self.name = name
         self.addr = addr
 
-    def receive(self) -> Tuple[bytes, List[bytes], List[bytearray]]:
+    def receive(self) -> Tuple[bytes, List[bytes], List[bytes]]:
         """Receive tasks from the server."""
         flag = self.socket.recv(self.LENGTH_TASK_FLAG)
         batch_size_bytes = self.socket.recv(self.LENGTH_TASK_BATCH)

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -17,8 +17,7 @@
 import logging
 import socket
 import struct
-from itertools import zip_longest
-from typing import List, Tuple
+from typing import Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +68,7 @@ class Protocol:
         self.name = name
         self.addr = addr
 
-    def receive(self) -> Tuple[bytes, List[bytes], List[bytes]]:
+    def receive(self) -> Tuple[bytes, Sequence[bytes], Sequence[bytes]]:
         """Receive tasks from the server."""
         flag = self.socket.recv(self.LENGTH_TASK_FLAG)
         batch_size_bytes = self.socket.recv(self.LENGTH_TASK_BATCH)
@@ -94,14 +93,16 @@ class Protocol:
             )
         return flag, ids, payloads
 
-    def send(self, flag: int, ids: List[bytes], payloads: List[bytes]):
+    def send(self, flag: int, ids: Sequence[bytes], payloads: Sequence[bytes]):
         """Send results to the server."""
         data = bytearray()
         data.extend(struct.pack(self.FORMAT_FLAG, flag))
+        if len(ids) != len(payloads):
+            raise ValueError("`ids` have different length with `payloads`")
         batch_size = len(ids)
         data.extend(struct.pack(self.FORMAT_BATCH, batch_size))
         if batch_size > 0:
-            for task_id, payload in zip_longest(ids, payloads, fillvalue=payloads[0]):
+            for task_id, payload in zip(ids, payloads):
                 length = struct.pack(self.FORMAT_LENGTH, len(payload))
                 data.extend(task_id)
                 data.extend(length)

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -239,7 +239,7 @@ class Server:
                     if self._coordinator_pools[stage_id][worker_id] is not None:
                         continue
 
-                    coordinator_process = mp.get_context(c_ctx).Process(
+                    coordinator_process = mp.get_context(c_ctx).Process(  # type: ignore
                         target=Coordinator,
                         args=(
                             w_cls,

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -147,20 +147,19 @@ class Server:
 
     def _check_daemon(self):
         for name, proc in self._daemon.items():
-            if proc is not None:
-                terminate = False
-                if isinstance(proc, mp.Process):
-                    code = proc.exitcode
-                elif isinstance(proc, subprocess.Popen):
-                    code = proc.poll()
-                if code:
-                    terminate = True
+            if proc is None:
+                continue
+            code = None
+            if isinstance(proc, mp.Process):
+                code = proc.exitcode
+            elif isinstance(proc, subprocess.Popen):
+                code = proc.poll()
 
-                if terminate:
-                    self._terminate(
-                        code,
-                        f"mosec daemon [{name}] exited on error code: {code}",
-                    )
+            if code:
+                self._terminate(
+                    code,
+                    f"mosec daemon [{name}] exited on error code: {code}",
+                )
 
     def _controller_args(self):
         args = []
@@ -290,7 +289,7 @@ class Server:
 
         logger.info("mosec server exited. see you.")
 
-    def register_daemon(self, name: str, proc: mp.Process):
+    def register_daemon(self, name: str, proc: subprocess.Popen):
         """Register a daemon to be monitored.
 
         Args:

--- a/mosec/worker.py
+++ b/mosec/worker.py
@@ -107,6 +107,10 @@ class Worker(abc.ABC):
         """
         return self._worker_id
 
+    @worker_id.setter
+    def worker_id(self, worker_id):
+        self._worker_id = worker_id
+
     def serialize(self, data: Any) -> bytes:
         """Serialize method for the last stage (egress).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,13 @@ write_to = "mosec/_version.py"
 
 [tool.mypy]
 warn_redundant_casts = true
-warn_unused_ignores = true
 warn_unreachable = true
 pretty = true
+
+[tool.pyright]
+pythonPlatform = "All"
+pythonVersion = "3.7"
+include = ["mosec", "tests", "examples"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
* fix #176 
* both `mypy` and `pyright` are kept here, I wonder if we should find a way to `make type-lint` success when at least one of `mypy` and `pyright` works