### PR TITLE
fix CI release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "mosec"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "bytes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ skip = "cp36-*"
 archs = ["auto64"]
 before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 environment = { PRODUCTION_MODE="yes", PATH="$PATH:$HOME/.cargo/bin", PIP_NO_CLEAN="yes" }
+before-build = "git status" # help to debug what happened to the setuptools_scm (file changes)
 
 [project.optional-dependencies]
 


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

* https://github.com/mosecorg/mosec/actions/runs/2833223032 failed because `Cargo.lock` will be updated after installing, so the rest builds will work on the dirty git env