### PR TITLE
chore: update CI os version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

* https://github.com/actions/runner-images/issues/6002
* https://github.com/actions/runner-images/issues/5583

Since we are using `cibuildwheel`, it should be able to audit the wheel correctly.