### PR TITLE
chore: skip existing packages for pypi upload

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -114,4 +114,4 @@ jobs:
           cargo login $CRATES_TOKEN
           cargo publish
           python setup.py sdist
-          twine upload dist/*
+          twine upload --skip-existing dist/*


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

This has caused a lot of CI failures.