### PR TITLE
refact: use argh as the CLI argument parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "argh"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c375edecfd2074d5edcc31396860b6e54b6f928714d0e097b983053fac0cabe3"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa013479b80109a1bf01a039412b0f0013d716f36921226d86c6709032fb7a03"
+dependencies = [
+ "argh_shared",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149f75bbec1827618262e0855a68f0f9a7f2edc13faebf33c4f16d6725edb6a9"
+
+[[package]]
 name = "async-channel"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,17 +49,6 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -62,45 +80,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clap"
-version = "3.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
- "clap_lex",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
-dependencies = [
- "os_str_bytes",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -176,12 +155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,16 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,9 +294,9 @@ dependencies = [
 name = "mosec"
 version = "0.4.1"
 dependencies = [
+ "argh",
  "async-channel",
  "bytes",
- "clap",
  "derive_more",
  "hyper",
  "once_cell",
@@ -362,12 +325,6 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 dependencies = [
  "parking_lot_core",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "parking_lot"
@@ -403,30 +360,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -556,12 +489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,21 +498,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -734,12 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,15 +676,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ derive_more = { version = "0.99.0", features = ["display", "error"] }
 async-channel = { version = "1.7.1" }
 parking_lot = "0.12"
 once_cell = { version = "1.15", features = ["parking_lot"] }
-clap = { version = "3.2", features = ["derive"] }
 prometheus = "0.13"
+argh = "0.1"

--- a/src/args.rs
+++ b/src/args.rs
@@ -12,41 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::Parser;
+use argh::FromArgs;
 
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[derive(FromArgs, Debug, PartialEq)]
+/// MOSEC arguments
 pub(crate) struct Opts {
-    /// Unix domain socket directory path
-    #[clap(long, default_value = "")]
+    /// the Unix domain socket directory path
+    #[argh(option, default = "String::from(\"\")")]
     pub(crate) path: String,
 
     /// batch size for each stage
-    #[clap(short, long, default_values = &["1", "8", "1"])]
+    #[argh(option)]
     pub(crate) batches: Vec<u32>,
 
     /// capacity for the channel
     /// (when the channel is full, the new requests will be dropped with 429 Too Many Requests)
-    #[clap(short, long, default_value = "1024")]
+    #[argh(option, short = 'c', default = "1024")]
     pub(crate) capacity: usize,
 
     /// timeout for one request (milliseconds)
-    #[clap(short, long, default_value = "3000")]
+    #[argh(option, short = 't', default = "3000")]
     pub(crate) timeout: u64,
 
     /// wait time for each batch (milliseconds)
-    #[clap(short, long, default_value = "10")]
+    #[argh(option, short = 'w', default = "10")]
     pub(crate) wait: u64,
 
     /// service host
-    #[clap(short, long, default_value = "0.0.0.0")]
+    #[argh(option, short = 'a', default = "String::from(\"0.0.0.0\")")]
     pub(crate) address: String,
 
     /// service port
-    #[clap(short, long, default_value = "8000")]
+    #[argh(option, short = 'p', default = "8000")]
     pub(crate) port: u16,
 
     /// metrics namespace
-    #[clap(short, long, default_value = "mosec_service")]
+    #[argh(option, short = 'n', default = "String::from(\"mosec_service\")")]
     pub(crate) namespace: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ mod tasks;
 use std::net::SocketAddr;
 
 use bytes::Bytes;
-use clap::Parser;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{body::to_bytes, header::HeaderValue, Body, Method, Request, Response, StatusCode};
 use prometheus::{Encoder, TextEncoder};
@@ -168,7 +167,7 @@ fn init_env() {
 #[tokio::main]
 async fn main() {
     init_env();
-    let opts: Opts = Opts::parse();
+    let opts: Opts = argh::from_env();
     info!(?opts, "parse arguments");
 
     let coordinator = Coordinator::init_from_opts(&opts);


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

The main reason is that we don't need many CLI parser features as `clap` provided. But the binary size and compiling time are what we care about.

:crying_cat_face: result doesn't show much difference. At least, the rust-analyzer won't show any warning/error on the `clap` macro anymore.

* size reduced from `2.9M` to `2.7M` on Linux
* compiling time tested on my laptop (AMD 5800):
  * debug: `21.69s` -> `19.27s`
  * release: `26.89s` -> `24.41s`