### PR TITLE
feat: check addr:port's availability

### DIFF
--- a/mosec/args.py
+++ b/mosec/args.py
@@ -21,9 +21,26 @@ Arguments parsing for two parts:
 """
 
 import argparse
+import errno
 import os
 import random
+import socket
 import tempfile
+
+
+def is_port_available(addr: str, port: int) -> bool:
+    """Check if the port is available to use"""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    err = sock.connect_ex((addr, port))
+    sock.close()
+    # https://docs.python.org/3/library/errno.html
+    if 0 == err:
+        return False
+    elif errno.ECONNREFUSED == err:
+        return True
+    raise RuntimeError(
+        f"Check {addr}:{port} socket connection err: {err}{errno.errorcode[err]}"
+    )
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -86,7 +103,11 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     args = parser.parse_args()
-    return args
+    if is_port_available(args.address, args.port):
+        return args
+    raise RuntimeError(
+        f"{args.address}:{args.port} is in use. Please change to a free one."
+    )
 
 
 if __name__ == "__main__":

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -27,9 +27,7 @@ import subprocess
 import traceback
 from functools import partial
 from multiprocessing.synchronize import Event
-from os.path import exists
 from pathlib import Path
-from shutil import rmtree
 from time import monotonic, sleep
 from typing import Dict, List, Optional, Type, Union
 
@@ -174,10 +172,6 @@ class Server:
         """Subprocess to start controller program."""
         self._configs = vars(parse_arguments())
         if not self._server_shutdown:
-            path = self._configs["path"]
-            if exists(path):
-                logger.info("path already exists, try to remove it: %s", path)
-                rmtree(path)
             path = Path(pkg_resources.resource_filename("mosec", "bin"), "mosec")
             # pylint: disable=consider-using-with
             self._controller_process = subprocess.Popen(


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

Previously error info:
```
2022-10-06 14:43:00,413 - 171032 - INFO - server.py:168 - Mosec Server Configurations: ['--path', '/tmp/mosec_d04f7777', '--capacity', '1024', '--timeout', '3000', '--wait', '10', '--address', '0.0.0.0', '--port', '8000', '--namespace', 'mosec_service', '--batches', '1', '--batches', '32', '--batches', '1']
2022-10-06T06:43:00.424583Z  INFO mosec: parse arguments opts=Opts { path: "/tmp/mosec_d04f7777", batches: [1, 32, 1], capacity: 1024, timeout: 3000, wait: 10, address: "0.0.0.0", port: 8000, namespace: "mosec_service" }
2022-10-06 14:43:00,574 - 171036 - INFO - protocol.py:122 - <1|Preprocess|1> socket connected to /tmp/mosec_d04f7777/ipc_1.socket
2022-10-06T06:43:00.575140Z  INFO mosec::protocol: accepted connection from addr=(unnamed)
2022-10-06 14:43:00,575 - 171037 - INFO - protocol.py:122 - <2|Inference|1> socket connected to /tmp/mosec_d04f7777/ipc_2.socket
2022-10-06T06:43:00.575304Z  INFO mosec::protocol: accepted connection from addr=(unnamed)
2022-10-06 14:43:00,576 - 171044 - INFO - protocol.py:122 - <3|Postprocess|1> socket connected to /tmp/mosec_d04f7777/ipc_3.socket
2022-10-06T06:43:00.576352Z  INFO mosec::protocol: accepted connection from addr=(unnamed)
thread 'main' panicked at 'error binding to 0.0.0.0:8000: error creating server listener: Address already in use (os error 98)', /home/keming/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.14.20/src/server/server.rs:77:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2022-10-06 14:43:00,576 - 171036 - ERROR - coordinator.py:233 - <1|Preprocess|1> socket receive error: unpack requires a buffer of 2 bytes
2022-10-06 14:43:00,576 - 171044 - ERROR - coordinator.py:233 - <3|Postprocess|1> socket receive error: unpack requires a buffer of 2 bytes
2022-10-06 14:43:00,576 - 171036 - INFO - protocol.py:127 - <1|Preprocess|1> socket closed
2022-10-06 14:43:00,576 - 171044 - INFO - protocol.py:127 - <3|Postprocess|1> socket closed
2022-10-06 14:43:00,576 - 171037 - ERROR - coordinator.py:233 - <2|Inference|1> socket receive error: unpack requires a buffer of 2 bytes
2022-10-06 14:43:00,577 - 171037 - INFO - protocol.py:127 - <2|Inference|1> socket closed
2022-10-06 14:43:01,418 - 171032 - INFO - server.py:183 - [101] terminating server [mosec daemon [controller] exited on error code: 101] ...
2022-10-06 14:43:01,578 - 171036 - ERROR - coordinator.py:159 - <1|Preprocess|1> socket connection error: [Errno 9] Bad file descriptor
2022-10-06 14:43:01,578 - 171044 - ERROR - coordinator.py:159 - <3|Postprocess|1> socket connection error: [Errno 9] Bad file descriptor
2022-10-06 14:43:01,578 - 171037 - ERROR - coordinator.py:159 - <2|Inference|1> socket connection error: [Errno 9] Bad file descriptor
2022-10-06 14:43:02,419 - 171032 - ERROR - server.py:273 - mosec controller halted on error: 101
2022-10-06 14:43:02,420 - 171032 - INFO - server.py:284 - mosec server exited. see you.
```

It's hard to find the correct root cause.

After this PR:

```
Traceback (most recent call last):
  File "/home/keming/GitHub/mosec/examples/echo.py", line 68, in <module>
    server.run()
  File "/home/keming/GitHub/mosec/mosec/server.py", line 328, in run
    self._start_controller()
  File "/home/keming/GitHub/mosec/mosec/server.py", line 173, in _start_controller
    self._configs = vars(parse_arguments())
  File "/home/keming/GitHub/mosec/mosec/args.py", line 108, in parse_arguments
    raise RuntimeError(
RuntimeError: 0.0.0.0:8000 is in use. Please change to a free one.
```