### PR TITLE
chore: add release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: What's Changed
+      labels:
+        - "*"


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

Ref: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes

We don't have a bot to automatically add the labels. But at least, we can exclude the PR made by the dependabot.