### PR TITLE
fix: delete the task if the notifier channel is closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "mosec"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "argh",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosec"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Keming <kemingy94@gmail.com>", "Zichen <lkevinzc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -218,7 +218,7 @@ class Server:
                     # this stage might contain bugs
                     self._terminate(
                         1,
-                        f"all workers at stage {stage_id} exited;"
+                        f"all the {w_cls.__name__} workers at stage {stage_id} exited;"
                         " please check for bugs or socket connection issues",
                     )
                     break


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

* fix https://github.com/mosecorg/mosec/issues/262

This is because when this connection is closed, the corresponding server tokio thread is also dead. So the created notifier channel is closed. Thus we need to delete the task since no one is going to use it.

Also, it's a bit ugly to put the metrics info in this task related method. Welcome other suggestions.

If it looks good, I'll also update the version and release a new one.