### PR TITLE
fix: ignore the rmtree error

### DIFF
--- a/mosec/server.py
+++ b/mosec/server.py
@@ -281,7 +281,7 @@ class Server:
 
         # shutdown coordinators
         self._coordinator_shutdown.set()
-        shutil.rmtree(self._configs["path"])
+        shutil.rmtree(self._configs["path"], ignore_errors=True)
         logger.info("mosec server exited. see you.")
 
     def register_daemon(self, name: str, proc: subprocess.Popen):


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

If we meet the Python spawn new process error, actually this dir is not created. So we can ignore this error.

Before:
```
2023-02-10 16:36:14,373 - 579501 - INFO - server.py:169 - Mosec Server Configurations: ['--path', '/tmp/mosec_bfad0b6f', '--capacity', '1024', '--timeout', '3000', '--wait', '10', '--address', '0.0.0.0', '--port', '8000', '--namespace', 'mosec_service', '--batches', '8']
2023-02-10 16:36:14,374 - 579501 - ERROR - server.py:334 - Traceback (most recent call last):   File "/home/keming/GitHub/mosec/mosec/server.py", line 331, in run     self._manage_coordinators()   File "/home/keming/GitHub/mosec/mosec/server.py", line 254, in _manage_coordinators     coordinator_process.start()   File "/opt/conda/lib/python3.9/multiprocessing/process.py", line 121, in start     self._popen = self._Popen(self)   File "/opt/conda/lib/python3.9/multiprocessing/context.py", line 284, in _Popen     return Popen(process_obj)   File "/opt/conda/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 32, in __init__     super().__init__(process_obj)   File "/opt/conda/lib/python3.9/multiprocessing/popen_fork.py", line 19, in __init__     self._launch(process_obj)   File "/opt/conda/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 47, in _launch     reduction.dump(process_obj, fp)   File "/opt/conda/lib/python3.9/multiprocessing/reduction.py", line 60, in dump     ForkingPickler(file, protocol).dump(obj) _pickle.PicklingError: Can't pickle <class 'abc.Inference'>: attribute lookup Inference on abc failed
2023-02-10 16:36:14,475 - 579501 - ERROR - server.py:274 - mosec controller halted on error: -15
Traceback (most recent call last):
  File "/home/keming/GitHub/serving_example/server.py", line 25, in <module>
    server.run()
  File "/home/keming/GitHub/mosec/mosec/server.py", line 335, in run
    self._halt()
  File "/home/keming/GitHub/mosec/mosec/server.py", line 284, in _halt
    shutil.rmtree(self._configs["path"])
  File "/opt/conda/lib/python3.9/shutil.py", line 722, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/opt/conda/lib/python3.9/shutil.py", line 720, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/mosec_bfad0b6f'
```

After:
```
2023-02-10 16:41:52,620 - 581248 - INFO - server.py:169 - Mosec Server Configurations: ['--path', '/tmp/mosec_75a76137', '--capacity', '1024', '--timeout', '3000', '--wait', '10', '--address', '0.0.0.0', '--port', '8000', '--namespace', 'mosec_service', '--batches', '8']
2023-02-10 16:41:52,623 - 581248 - ERROR - server.py:334 - Traceback (most recent call last):   File "/home/keming/GitHub/mosec/mosec/server.py", line 331, in run     self._manage_coordinators()   File "/home/keming/GitHub/mosec/mosec/server.py", line 254, in _manage_coordinators     coordinator_process.start()   File "/opt/conda/lib/python3.9/multiprocessing/process.py", line 121, in start     self._popen = self._Popen(self)   File "/opt/conda/lib/python3.9/multiprocessing/context.py", line 284, in _Popen     return Popen(process_obj)   File "/opt/conda/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 32, in __init__     super().__init__(process_obj)   File "/opt/conda/lib/python3.9/multiprocessing/popen_fork.py", line 19, in __init__     self._launch(process_obj)   File "/opt/conda/lib/python3.9/multiprocessing/popen_spawn_posix.py", line 47, in _launch     reduction.dump(process_obj, fp)   File "/opt/conda/lib/python3.9/multiprocessing/reduction.py", line 60, in dump     ForkingPickler(file, protocol).dump(obj) _pickle.PicklingError: Can't pickle <class 'abc.Inference'>: attribute lookup Inference on abc failed
2023-02-10 16:41:52,723 - 581248 - ERROR - server.py:274 - mosec controller halted on error: -15
2023-02-10 16:41:52,724 - 581248 - INFO - server.py:285 - mosec server exited. see you.
```