### PR TITLE
fix: warn about the timeout and channel is full

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "mosec"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "argh",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosec"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Keming <kemingy94@gmail.com>", "Zichen <lkevinzc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -103,7 +103,7 @@ impl TaskManager {
     pub(crate) async fn submit_task(&self, data: Bytes) -> Result<Task, ServiceError> {
         let (id, rx) = self.add_new_task(data)?;
         if let Err(err) = time::timeout(self.timeout, rx).await {
-            error!(%id, %err, "task timeout");
+            warn!(%id, %err, "task timeout");
             let mut table = self.table.write();
             let mut notifiers = self.notifiers.lock();
             table.remove(&id);
@@ -139,7 +139,7 @@ impl TaskManager {
         debug!(%id, "add a new task");
 
         if self.channel.try_send(id).is_err() {
-            error!(%id, "the first channel is full, delete this task");
+            warn!(%id, "the first channel is full, delete this task");
             table.remove(&id);
             notifiers.remove(&id);
             return Err(ServiceError::TooManyRequests);


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

They are not errors that users need to handle. We should use WARNING instead of ERROR.