### PR TITLE
feat: support colorful log for debug and json log for production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -116,30 +116,30 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "lazy_static"
@@ -227,9 +227,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lock_api"
@@ -251,15 +251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,19 +258,19 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "mosec"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "argh",
  "async-channel",
@@ -306,19 +297,28 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.0"
+name = "num_threads"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 dependencies = [
  "parking_lot_core",
 ]
@@ -341,15 +341,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -366,9 +366,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -396,9 +396,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -413,30 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,9 +435,26 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+
+[[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+
+[[package]]
+name = "serde_json"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -468,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -493,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -504,18 +503,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -524,11 +523,41 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -547,14 +576,14 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -612,34 +641,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
+ "time",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "valuable"
@@ -701,43 +740,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosec"
-version = "0.4.9"
+version = "0.5.0"
 authors = ["Keming <kemingy94@gmail.com>", "Zichen <lkevinzc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ exclude = ["target", "examples", "tests", "scripts"]
 hyper = { version = "0.14", features = ["http1", "server", "runtime"] }
 bytes = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["local-time", "json"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros", "sync", "signal", "io-util"] }
 derive_more = { version = "0.99", features = ["display", "error"] }
 async-channel = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -53,19 +53,9 @@ Mosec requires Python 3.7 or above. Install the latest [PyPI package](https://py
 Import the libraries and set up a basic logger to better observe what happens.
 
 ```python
-import logging
+from mosec import Server, Worker, ValidationError, get_logger
 
-from mosec import Server, Worker
-from mosec.errors import ValidationError
-
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
+logger = get_logger()
 ```
 
 Then, we **build an API** to calculate the exponential with base **e** for a given number. To achieve that, we simply inherit the `Worker` class and override the `forward` method. Note that the input `req` is by default a JSON-decoded object, e.g., a dictionary here (wishfully it receives data like `{"x": 1}`). We also enclose the input parsing part with a `try...except...` block to reject invalid input (e.g., no key named `"x"` or field `"x"` cannot be converted to `float`).
@@ -107,10 +97,10 @@ After merging the snippets above into a file named `server.py`, we can first hav
 > python server.py --help
 ```
 
-Then let's start the server...
+Then let's start the server with debug logs:
 
 ```shell
-> python server.py
+> python server.py --debug
 ```
 
 and in another terminal, test it:
@@ -129,16 +119,6 @@ or check the metrics:
 
 ```shell
 > curl http://127.0.0.1:8000/metrics
-```
-
-For more debug logs, you can enable it by changing the Python & Rust log level:
-
-```python
-logger.setLevel(logging.DEBUG)
-```
-
-```shell
-> RUST_LOG=debug python server.py
 ```
 
 That's it! You have just hosted your **_exponential-computing model_** as a server! 😉
@@ -161,7 +141,7 @@ More ready-to-use examples can be found in the [Example](https://mosecorg.github
 
 We welcome any kind of contribution. Please give us feedback by [raising issues](https://github.com/mosecorg/mosec/issues/new/choose) or discussing on [Discord](https://discord.gg/Jq5vxuH69W). You could also directly [contribute](https://mosecorg.github.io/mosec/contributing) your code and pull request!
 
-To start develop, you can use [envd](https://github.com/tensorchord/envd) to create an isolated and clean Python & Rust environment. Check the [envd-docs](https://envd.tensorchord.ai/) or [build.envd](./build.envd) for more information.
+To start develop, you can use [envd](https://github.com/tensorchord/envd) to create an isolated and clean Python & Rust environment. Check the [envd-docs](https://envd.tensorchord.ai/) or [build.envd](https://github.com/mosecorg/mosec/blob/main/build.envd) for more information.
 
 ## Qualitative Comparison<sup>\*</sup>
 

--- a/examples/custom_env.py
+++ b/examples/custom_env.py
@@ -13,19 +13,11 @@
 # limitations under the License.
 """Example: Custom Environment setup"""
 
-import logging
 import os
 
-from mosec import Server, Worker
+from mosec import Server, Worker, get_logger
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
+logger = get_logger()
 
 
 class Inference(Worker):

--- a/examples/distil_bert_server_pytorch.py
+++ b/examples/distil_bert_server_pytorch.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Example: Mosec with Pytorch Distil BERT."""
 
-import logging
 from typing import Any, List
 
 import torch  # type: ignore
@@ -22,19 +21,12 @@ from transformers import (  # type: ignore
     AutoTokenizer,
 )
 
-from mosec import Server, Worker
+from mosec import Server, Worker, get_logger
+
+logger = get_logger()
 
 # type alias
 Returns = Any
-
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
 
 INFERENCE_BATCH_SIZE = 32
 

--- a/examples/echo.py
+++ b/examples/echo.py
@@ -13,21 +13,12 @@
 # limitations under the License.
 """Example: Sample structures for using mosec server."""
 
-import logging
 import time
 from typing import List
 
-from mosec import Server, Worker
-from mosec.errors import ValidationError
+from mosec import Server, ValidationError, Worker, get_logger
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
+logger = get_logger()
 
 
 class Preprocess(Worker):

--- a/examples/jax_single_layer.py
+++ b/examples/jax_single_layer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Example: Simple jax jitted inference with a single layer classifier."""
 
-import logging
 import os
 import time
 from typing import List
@@ -22,17 +21,9 @@ import chex  # type: ignore
 import jax  # type: ignore
 import jax.numpy as jnp  # type: ignore
 
-from mosec import Server, Worker
-from mosec.errors import ValidationError
+from mosec import Server, ValidationError, Worker, get_logger
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
+logger = get_logger()
 
 INPUT_SIZE = 3
 LATENT_SIZE = 16
@@ -61,9 +52,9 @@ class JittedInference(Worker):
             self.multi_examples.append([{"array": dummy_array}] * (i + 1))
 
         if USE_JIT == "true":
-            self.batch_forward = jax.jit(self._batch_foward)
+            self.batch_forward = jax.jit(self._batch_forward)
         else:
-            self.batch_forward = self._batch_foward
+            self.batch_forward = self._batch_forward
 
     def _forward(self, x_single: jnp.ndarray) -> jnp.ndarray:
         chex.assert_rank([x_single], [1])
@@ -73,7 +64,7 @@ class JittedInference(Worker):
         o_2 = jax.nn.softmax(h_2)
         return jnp.argmax(o_2, axis=-1)
 
-    def _batch_foward(self, x_batch: jnp.ndarray) -> jnp.ndarray:
+    def _batch_forward(self, x_batch: jnp.ndarray) -> jnp.ndarray:
         chex.assert_rank([x_batch], [2])
         return jax.vmap(self._forward)(x_batch)
 

--- a/examples/plasma_shm_ipc.py
+++ b/examples/plasma_shm_ipc.py
@@ -25,8 +25,7 @@ from functools import partial
 
 from pyarrow import plasma  # type: ignore
 
-from mosec import Server, Worker
-from mosec.errors import ValidationError
+from mosec import Server, ValidationError, Worker
 from mosec.plugins import PlasmaShmWrapper
 
 

--- a/examples/python_side_metrics.py
+++ b/examples/python_side_metrics.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Example: Adding metrics service."""
 
-import logging
 import os
 import pathlib
 import tempfile
@@ -26,17 +25,9 @@ from prometheus_client import (  # type: ignore
     start_http_server,
 )
 
-from mosec import Server, Worker
-from mosec.errors import ValidationError
+from mosec import Server, ValidationError, Worker, get_logger
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
+logger = get_logger()
 
 
 # check the PROMETHEUS_MULTIPROC_DIR environment variable before import Prometheus

--- a/examples/resnet50_server_msgpack.py
+++ b/examples/resnet50_server_msgpack.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Example: Sample Resnet server."""
 
-import logging
 from io import BytesIO
 from typing import List
 from urllib.request import urlretrieve
@@ -24,18 +23,10 @@ import torchvision  # type: ignore
 from PIL import Image  # type: ignore
 from torchvision import transforms  # type: ignore
 
-from mosec import Server, Worker
-from mosec.errors import ValidationError
+from mosec import Server, ValidationError, Worker, get_logger
 from mosec.mixin import MsgpackMixin
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
+logger = get_logger()
 
 INFERENCE_BATCH_SIZE = 16
 

--- a/examples/stable_diffusion/server.py
+++ b/examples/stable_diffusion/server.py
@@ -12,24 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from io import BytesIO
 from typing import List
 
 import torch  # type: ignore
 from diffusers import StableDiffusionPipeline  # type: ignore
 
-from mosec import Server, Worker
+from mosec import Server, Worker, get_logger
 from mosec.mixin import MsgpackMixin
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-formatter = logging.Formatter(
-    "%(asctime)s - %(process)d - %(levelname)s - %(filename)s:%(lineno)s - %(message)s"
-)
-sh = logging.StreamHandler()
-sh.setFormatter(formatter)
-logger.addHandler(sh)
+logger = get_logger()
 
 
 class StableDiffusion(MsgpackMixin, Worker):

--- a/mosec/__init__.py
+++ b/mosec/__init__.py
@@ -14,8 +14,6 @@
 
 """MOSEC is a machine learning model serving framework."""
 
-import logging
-
 from .errors import (
     ClientError,
     DecodingError,
@@ -23,6 +21,7 @@ from .errors import (
     ServerError,
     ValidationError,
 )
+from .log import get_logger
 from .server import Server
 from .worker import Worker
 
@@ -41,7 +40,5 @@ __all__ = [
     "ValidationError",
     "EncodingError",
     "DecodingError",
+    "get_logger",
 ]
-
-# setup library logging
-logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/mosec/args.py
+++ b/mosec/args.py
@@ -27,6 +27,8 @@ import random
 import socket
 import tempfile
 
+from .log import set_logger
+
 
 def is_port_available(addr: str, port: int) -> bool:
     """Check if the port is available to use."""
@@ -102,13 +104,18 @@ def parse_arguments() -> argparse.Namespace:
         default="mosec_service",
     )
 
-    args, _ = parser.parse_known_args()
-    if is_port_available(args.address, args.port):
-        return args
-    raise RuntimeError(
-        f"{args.address}:{args.port} is in use. Please change to a free one (--port)."
+    parser.add_argument(
+        "--debug",
+        help="Enable log format",
+        action="store_true",
     )
 
+    args, _ = parser.parse_known_args()
+    set_logger(args.debug)
+    if not is_port_available(args.address, args.port):
+        raise RuntimeError(
+            f"{args.address}:{args.port} is in use. "
+            "Please change to a free one (use `--port`)."
+        )
 
-if __name__ == "__main__":
-    parse_arguments()
+    return args

--- a/mosec/args.py
+++ b/mosec/args.py
@@ -27,8 +27,6 @@ import random
 import socket
 import tempfile
 
-from .log import set_logger
-
 
 def is_port_available(addr: str, port: int) -> bool:
     """Check if the port is available to use."""
@@ -111,7 +109,6 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     args, _ = parser.parse_known_args()
-    set_logger(args.debug)
     if not is_port_available(args.address, args.port):
         raise RuntimeError(
             f"{args.address}:{args.port} is in use. "
@@ -119,3 +116,6 @@ def parse_arguments() -> argparse.Namespace:
         )
 
     return args
+
+
+mosec_args = parse_arguments()

--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -14,7 +14,6 @@
 
 """The Coordinator is used to control the data flow between `Worker` and `Server`."""
 
-import logging
 import os
 import signal
 import socket
@@ -26,10 +25,11 @@ from typing import Any, Callable, Optional, Sequence, Tuple, Type
 
 from .errors import MosecError
 from .ipc import IPCWrapper
+from .log import get_logger
 from .protocol import HTTPStautsCode, Protocol
 from .worker import Worker
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 
 
 CONN_MAX_RETRY = 10

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -1,0 +1,144 @@
+# Copyright 2022 MOSEC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MOSEC multiprocessing logging configurations."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any, MutableMapping
+
+MOSEC_LOG_NAME = __name__
+
+
+class MosecFormat(logging.Formatter):
+    """Basic mosec log formatter.
+
+    This class uses `datetime` instead of `localtime` to get accurate milliseconds.
+    """
+
+    default_time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
+
+    def formatTime(self, record: logging.LogRecord, datefmt=None) -> str:
+        """Convert to datetime with timezone."""
+        time = datetime.utcfromtimestamp(record.created).astimezone()
+        return datetime.strftime(time, datefmt if datefmt else self.default_time_format)
+
+
+class DebugFormat(MosecFormat):
+    """Colorful debug formatter."""
+
+    Purple = "\x1b[35m"
+    Blue = "\x1b[34m"
+    Green = "\x1b[32m"
+    Yellow = "\x1b[33m"
+    Red = "\x1b[31m"
+    Reset = "\x1b[0m"
+
+    default_format = (
+        "%(asctime)s %(levelname)s %(filename)s:%(lineno)s"
+        " [%(process)d]: %(message)s"
+    )
+
+    def __init__(self, fmt: str | None = None, datefmt: str | None = None) -> None:
+        """Init with `%` style format.
+
+        Args:
+            fmt (str): logging message format (% style)
+            datefmt (str): datatime format
+        """
+        # partially align with rust tracing_subscriber
+        self.colors = {
+            logging.DEBUG: self.Blue,
+            logging.INFO: self.Green,
+            logging.WARNING: self.Yellow,
+            logging.ERROR: self.Red,
+            logging.CRITICAL: self.Purple,
+        }
+        super().__init__(fmt or self.default_format, datefmt, "%")
+
+    def format_level(self, name: str, level: int) -> str:
+        """Format a level name with the corresponding color."""
+        if level not in self.colors:
+            return name
+        return f"{self.colors[level]}{name}{self.Reset}"
+
+    def formatMessage(self, record: logging.LogRecord) -> str:
+        """Format the logging with colorful level names."""
+        fmt = self.default_format.replace(
+            "%(levelname)s",
+            self.format_level(record.levelname, record.levelno),
+        )
+        return fmt % record.__dict__
+
+
+class JSONFormat(MosecFormat):
+    """JSON log formatter."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format to a JSON string."""
+        # yet another mypy type-check issue
+        # https://github.com/python/mypy/issues/2900
+        res: MutableMapping[str, Any] = {
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "fields": {
+                "message": record.getMessage(),
+            },
+            "target": f"{record.filename}:{record.funcName}",
+        }
+        if record.exc_info:
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+            res["fields"]["exc_info"] = record.exc_text
+        if record.stack_info:
+            res["fields"]["stack_info"] = self.formatStack(record.stack_info)
+        return json.dumps(res)
+
+
+def use_log(level: int, formatter: logging.Formatter):
+    """Configure the global log."""
+    logger = logging.getLogger(MOSEC_LOG_NAME)
+    logger.setLevel(level)
+    if not logger.handlers:
+        stream = logging.StreamHandler()
+        stream.setFormatter(formatter)
+        logger.addHandler(stream)
+    return logger
+
+
+def use_pretty_log(level: int = logging.DEBUG):
+    """Enable colorful log."""
+    return use_log(level, DebugFormat())
+
+
+def use_json_log(level: int = logging.INFO):
+    """Enable JSON format log."""
+    return use_log(level, JSONFormat())
+
+
+def get_logger():
+    """Get the logger used by mosec for multiprocessing."""
+    if os.environ.get(MOSEC_LOG_NAME, "") == str(logging.DEBUG):
+        return use_pretty_log()
+    return use_json_log()
+
+
+def set_logger(debug=False):
+    """Set the logger environment so all the sub-processing can inhirit it."""
+    if debug:
+        os.environ[MOSEC_LOG_NAME] = str(logging.DEBUG)

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -139,6 +139,6 @@ def get_logger():
 
 
 def set_logger(debug=False):
-    """Set the logger environment so all the sub-processing can inhirit it."""
+    """Set the environment variable so all the sub-processes can inherit it."""
     if debug:
         os.environ[MOSEC_LOG_NAME] = str(logging.DEBUG)

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -35,7 +35,7 @@ class MosecFormat(logging.Formatter):
 
     def formatTime(self, record: logging.LogRecord, datefmt=None) -> str:
         """Convert to datetime with timezone."""
-        time = datetime.utcfromtimestamp(record.created).astimezone()
+        time = datetime.fromtimestamp(record.created).astimezone()
         return datetime.strftime(time, datefmt if datefmt else self.default_time_format)
 
 

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MOSEC Authors
+# Copyright 2023 MOSEC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -22,6 +22,8 @@ import os
 from datetime import datetime
 from typing import Any, MutableMapping
 
+from .args import mosec_args
+
 MOSEC_LOG_NAME = __name__
 
 
@@ -142,3 +144,7 @@ def set_logger(debug=False):
     """Set the environment variable so all the sub-processes can inherit it."""
     if debug:
         os.environ[MOSEC_LOG_NAME] = str(logging.DEBUG)
+
+
+# need to configure it here to make sure all the process can get the same one
+set_logger(mosec_args.debug)

--- a/mosec/plugins/plasma_shm.py
+++ b/mosec/plugins/plasma_shm.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, List
 
 from ..ipc import IPCWrapper
 
-# We do not enforce the installation of third party libaries for
+# We do not enforce the installation of third party libraries for
 # plugins, because users may not enable them.
 try:
     from pyarrow import plasma  # type: ignore

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -22,7 +22,9 @@ from enum import IntFlag
 from io import BytesIO
 from typing import Sequence, Tuple
 
-logger = logging.getLogger(__name__)
+from .log import get_logger
+
+logger = get_logger()
 
 IPC_LARGE_DATA_SIZE = 1024 * 1024  # set as 1 MB
 

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -33,7 +33,7 @@ from typing import Dict, List, Optional, Type, Union
 
 import pkg_resources
 
-from .args import parse_arguments
+from .args import mosec_args
 from .coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
 from .ipc import IPCWrapper
 from .log import get_logger
@@ -171,7 +171,7 @@ class Server:
 
     def _start_controller(self):
         """Subprocess to start controller program."""
-        self._configs = vars(parse_arguments())
+        self._configs = vars(mosec_args)
         if not self._server_shutdown:
             path = Path(pkg_resources.resource_filename("mosec", "bin"), "mosec")
             # pylint: disable=consider-using-with

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -19,7 +19,6 @@ model serving.
 """
 
 import contextlib
-import logging
 import multiprocessing as mp
 import os
 import shutil
@@ -37,9 +36,10 @@ import pkg_resources
 from .args import parse_arguments
 from .coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
 from .ipc import IPCWrapper
+from .log import get_logger
 from .worker import Worker
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 
 
 GUARD_CHECK_INTERVAL = 1
@@ -163,10 +163,10 @@ class Server:
     def _controller_args(self):
         args = []
         for key, value in self._configs.items():
-            args.extend([f"--{key}", str(value)])
+            args.extend([f"--{key}", str(value).lower()])
         for batch_size in self._worker_mbs:
             args.extend(["--batches", str(batch_size)])
-        logger.info("Mosec Server Configurations: %s", args)
+        logger.info("mosec server configurations: %s", args)
         return args
 
     def _start_controller(self):
@@ -282,7 +282,7 @@ class Server:
         # shutdown coordinators
         self._coordinator_shutdown.set()
         shutil.rmtree(self._configs["path"], ignore_errors=True)
-        logger.info("mosec server exited. see you.")
+        logger.info("mosec server exited normally")
 
     def register_daemon(self, name: str, proc: subprocess.Popen):
         """Register a daemon to be monitored.

--- a/mosec/worker.py
+++ b/mosec/worker.py
@@ -28,9 +28,6 @@ import pickle
 from typing import Any, Sequence
 
 from .errors import DecodingError, EncodingError
-from .log import get_logger
-
-logger = get_logger()
 
 
 class Worker(abc.ABC):

--- a/mosec/worker.py
+++ b/mosec/worker.py
@@ -24,13 +24,13 @@ This module provides the interface to define a worker with such behaviors:
 
 import abc
 import json
-import logging
 import pickle
 from typing import Any, Sequence
 
 from .errors import DecodingError, EncodingError
+from .log import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger()
 
 
 class Worker(abc.ABC):
@@ -41,7 +41,7 @@ class Worker(abc.ABC):
     be implemented by the users.
 
     By default, we use [JSON](https://www.json.org/) encoding. But users
-    are free to customize via simply overridding the `deserialize` method
+    are free to customize via simply overriding the `deserialize` method
     in the **first** stage (we term it as _ingress_ stage) and/or
     the `serialize` method in the **last** stage (we term it as _egress_ stage).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,6 @@ pythonPlatform = "All"
 pythonVersion = "3.7"
 include = ["mosec", "tests", "examples"]
 
-[tool.ruff]
-select = ["A", "B", "C4", "E", "F", "I", "W", "C90", "N", "PL"]
-[tool.ruff.pylint]
-max-args = 10
-
 [tool.isort]
 profile = "black"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ pythonPlatform = "All"
 pythonVersion = "3.7"
 include = ["mosec", "tests", "examples"]
 
+[tool.ruff]
+select = ["A", "B", "C4", "E", "F", "I", "W", "C90", "N", "PL"]
+[tool.ruff.pylint]
+max-args = 10
+
 [tool.isort]
 profile = "black"
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -49,4 +49,8 @@ pub(crate) struct Opts {
     /// metrics namespace
     #[argh(option, short = 'n', default = "String::from(\"mosec_service\")")]
     pub(crate) namespace: String,
+
+    /// enable debug log
+    #[argh(option, short = 'd', default = "false")]
+    pub(crate) debug: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn main() {
     let timer = OffsetTime::local_rfc_3339().expect("local time offset");
     if opts.debug {
         // use colorful log for debug
-        let output = tracing_subscriber::fmt::layer().compact();
+        let output = tracing_subscriber::fmt::layer().compact().with_timer(timer);
         tracing_subscriber::registry()
             .with(
                 output

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,8 @@ use hyper::{body::to_bytes, header::HeaderValue, Body, Method, Request, Response
 use prometheus::{Encoder, TextEncoder};
 use tokio::signal::unix::{signal, SignalKind};
 use tracing::info;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::time::OffsetTime;
+use tracing_subscriber::{filter, prelude::*, Layer};
 
 use crate::args::Opts;
 use crate::coordinator::Coordinator;
@@ -154,23 +155,9 @@ async fn shutdown_signal() {
     }
 }
 
-fn init_env() {
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info")
-    }
-
-    tracing_subscriber::fmt::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
-}
-
 #[tokio::main]
-async fn main() {
-    init_env();
-    let opts: Opts = argh::from_env();
-    info!(?opts, "parse arguments");
-
-    let coordinator = Coordinator::init_from_opts(&opts);
+async fn run(opts: &Opts) {
+    let coordinator = Coordinator::init_from_opts(opts);
     let barrier = coordinator.run();
     barrier.wait().await;
 
@@ -182,4 +169,34 @@ async fn main() {
     if let Err(err) = graceful.await {
         tracing::error!(%err, "server error");
     }
+}
+
+fn main() {
+    let opts: Opts = argh::from_env();
+
+    // this has to be defined before tokio multi-threads
+    let timer = OffsetTime::local_rfc_3339().expect("local time offset");
+    if opts.debug {
+        // use colorful log for debug
+        let output = tracing_subscriber::fmt::layer().compact();
+        tracing_subscriber::registry()
+            .with(
+                output
+                    .with_filter(filter::filter_fn(|metadata| {
+                        !metadata.target().starts_with("hyper")
+                    }))
+                    .with_filter(filter::LevelFilter::DEBUG),
+            )
+            .init();
+    } else {
+        // use JSON format for production
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .json()
+            .with_timer(timer)
+            .init();
+    }
+
+    info!(?opts, "parse arguments");
+    run(&opts);
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -30,7 +30,7 @@ import pytest
 
 from mosec.coordinator import PROTOCOL_TIMEOUT, STAGE_EGRESS, STAGE_INGRESS, Coordinator
 from mosec.mixin import MsgpackMixin
-from mosec.protocol import HTTPStautsCode, Protocol, _recv_all
+from mosec.protocol import HTTPStautsCode, _recv_all
 from mosec.worker import Worker
 
 from .utils import imitate_controller_send

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -62,11 +62,9 @@ def mosec_service(request):
 def test_square_service(mosec_service, http_client):
     resp = http_client.get("/")
     assert resp.status_code == 200
-    # only check the major and minor version since Python is using `setuptools-scm`
-    major_minor_version = ".".join(mosec.__version__.split(".", 3)[:2])
-    assert resp.headers["server"].startswith(
-        "mosec/" + major_minor_version
-    ), f"{mosec.__version__} ({major_minor_version}) vs {resp.headers['server']}"
+    # only check the prefix since the version from setuptools_scm may not be the
+    # correct one used in `Cargo.toml`
+    assert resp.headers["server"].startswith("mosec/"), f"{resp.headers['server']}"
 
     resp = http_client.get("/metrics")
     assert resp.status_code == 200


### PR DESCRIPTION
Target:
- provide a convenient way to set up the logging for both Python & Rust
- try to align the format of Python & Rust
- use JSON format for production, use colorful string for local debug
- filter Rust low level log like hyper and mio

Also, it's hard to set up the logging for Python because we heavily rely on multiprocessing. Thus the only way is to create the logger from a single source. For now, I think we can use a runtime environment variable since it will be inherited by all the children processing.

Welcome suggestions.