### PR TITLE
feat: enable configuring wait time for different stages

### DIFF
--- a/mosec/args.py
+++ b/mosec/args.py
@@ -26,6 +26,7 @@ import os
 import random
 import socket
 import tempfile
+import warnings
 
 
 def is_port_available(addr: str, port: int) -> bool:
@@ -76,7 +77,7 @@ def parse_arguments() -> argparse.Namespace:
 
     parser.add_argument(
         "--wait",
-        help="Wait time for the batcher to batch (milliseconds)",
+        help="[deprecated] Wait time for the batcher to batch (milliseconds)",
         type=int,
         default=10,
     )
@@ -109,6 +110,14 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     args, _ = parser.parse_known_args()
+
+    if args.wait != 10:
+        warnings.warn(
+            "`--wait` is deprecated and will be removed in v1, please configure"
+            "the `max_wait_time` on `Server.append_worker`",
+            DeprecationWarning,
+        )
+
     if not is_port_available(args.address, args.port):
         raise RuntimeError(
             f"{args.address}:{args.port} is in use. "

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -329,7 +329,7 @@ class Server:
                 dynamic batching if it > 1
             max_wait_time: the maximum wait time (millisecond) for dynamic batching,
                 needs to be used with `max_batch_size` to enable the feature. If not
-                configure, will use 10ms.
+                configure, will use the CLI argument `--wait` (default=10ms)
             start_method: the process starting method ("spawn" or "fork")
             env: the environment variables to set before starting the process
         """

--- a/mosec/worker.py
+++ b/mosec/worker.py
@@ -178,10 +178,10 @@ class Worker(abc.ABC):
 
         .. note::
 
-            - for a single-stage worker, data will go throught
+            - for a single-stage worker, data will go through
                 ``<deserialize> -> <forward> -> <serialize>``
 
             - for a multi-stage worker that is neithor `ingress` not `egress`, data
-                will go throught ``<deserialize_ipc> -> <forward> -> <serialize_ipc>``
+                will go through ``<deserialize_ipc> -> <forward> -> <serialize_ipc>``
         """
         raise NotImplementedError

--- a/src/args.rs
+++ b/src/args.rs
@@ -21,7 +21,7 @@ pub(crate) struct Opts {
     #[argh(option, default = "String::from(\"\")")]
     pub(crate) path: String,
 
-    /// batch size for each stage
+    /// max batch size for each stage
     #[argh(option)]
     pub(crate) batches: Vec<u32>,
 
@@ -34,9 +34,13 @@ pub(crate) struct Opts {
     #[argh(option, short = 't', default = "3000")]
     pub(crate) timeout: u64,
 
-    /// wait time for each batch (milliseconds)
+    /// wait time for each batch (milliseconds), use `waits` instead [deprecated]
     #[argh(option, short = 'w', default = "10")]
     pub(crate) wait: u64,
+
+    /// max wait time for each stage
+    #[argh(option)]
+    pub(crate) waits: Vec<u64>,
 
     /// service host
     #[argh(option, short = 'a', default = "String::from(\"0.0.0.0\")")]


### PR DESCRIPTION
Since mosec supports dynamic batching for any stage, we should also support this.

This is a breaking change but the current interface remains the same. I think we can delete the legacy code before releasing v1.