### PR TITLE
fix: align warmup example format in dry run

### DIFF
--- a/examples/echo.py
+++ b/examples/echo.py
@@ -24,7 +24,7 @@ logger = get_logger()
 class Preprocess(Worker):
     """Sample Class."""
 
-    example = [{"time": 0}]
+    example = {"time": 0}
 
     def forward(self, data: dict) -> float:
         logger.debug("pre received %s", data)
@@ -38,6 +38,8 @@ class Preprocess(Worker):
 
 class Inference(Worker):
     """Sample Class."""
+
+    example = [0, 1e-5, 2e-4]
 
     def forward(self, data: List[float]) -> List[float]:
         logger.info("sleeping for %s seconds", max(data))

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -143,15 +143,12 @@ class DryRunner:
         ingress = self.workers[0]
         example = None
         if ingress.example:
-            assert isinstance(
-                ingress.example, list
-            ), "`example` should be a list of data"
-            example = ingress.example[0]
+            example = ingress.example
         elif ingress.multi_examples:
-            assert isinstance(ingress.multi_examples, list) and isinstance(
-                ingress.multi_examples[0], list
-            ), "`multi_examples` should be a list of list data"
-            example = ingress.multi_examples[0][0]
+            assert isinstance(ingress.multi_examples, list), (
+                "`multi_examples` " "should be a list of data"
+            )
+            example = ingress.multi_examples[0]
 
         if not example:
             logger.info("cannot find the example in the 1st stage worker, skip warmup")


### PR DESCRIPTION
For now, the `example` attribute should be a valid input for this worker. This means, if the worker has dynamic batching, then the input should be a list, vice versa.