### PR TITLE
fix: resolve deadlock when lots of client requests closed before response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "mosec"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "argh",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosec"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Keming <kemingy94@gmail.com>", "Zichen <lkevinzc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -293,8 +293,10 @@ class Server:
                         logger.info("mosec service halted normally [%d]", ctr_exitcode)
                     break
                 sleep(0.1)
-            logger.error("failed to terminate mosec service, will try to kill it")
-            self._controller_process.kill()
+
+            if monotonic() > graceful_period:
+                logger.error("failed to terminate mosec service, will try to kill it")
+                self._controller_process.kill()
 
         # shutdown coordinators
         self._coordinator_shutdown.set()

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -167,7 +167,7 @@ class Server:
             elif isinstance(proc, subprocess.Popen):
                 code = proc.poll()
 
-            if code:
+            if code is not None:
                 self._terminate(
                     code,
                     f"mosec daemon [{name}] exited on error code: {code}",
@@ -281,18 +281,20 @@ class Server:
         self._coordinator_shutdown_notify.set()
 
         # terminate controller first and wait for a graceful period
-        if self._controller_process:
+        if self._controller_process is not None:
             self._controller_process.terminate()
             graceful_period = monotonic() + self._configs["timeout"] / 1000
             while monotonic() < graceful_period:
                 ctr_exitcode = self._controller_process.poll()
                 if ctr_exitcode is not None:  # exited
                     if ctr_exitcode:  # on error
-                        logger.error("mosec service halted on error: %d", ctr_exitcode)
+                        logger.error("mosec service halted on error [%d]", ctr_exitcode)
                     else:
-                        logger.info("mosec service halted normally")
+                        logger.info("mosec service halted normally [%d]", ctr_exitcode)
                     break
                 sleep(0.1)
+            logger.error("failed to terminate mosec service, will try to kill it")
+            self._controller_process.kill()
 
         # shutdown coordinators
         self._coordinator_shutdown.set()


### PR DESCRIPTION
Reproduce the bug:

`python examples/echo.py --debug`

```python
import concurrent.futures
import requests
import random


URL = "http://localhost:8000/inference"


def random_req(params, timeout):
    resp = requests.post(URL, json=params, timeout=timeout)
    return resp


with concurrent.futures.ThreadPoolExecutor(max_workers=16) as e:
    futures = [
        e.submit(random_req, {"time": 0.1}, random.random() / 5.0) for _ in range(1000)
    ]
    for future in concurrent.futures.as_completed(futures):
        try:
            data = future.result()
        except Exception as err:
            print(err)
        else:
            print(data)
```

`python bad_req.py`
