### PR TITLE
chore: skip the lint&test step in release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,57 +9,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - uses: ./.github/actions/cache
-      - name: Install dependencies
-        run: make install
-      - name: install node for pyright
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: install pyright
-        run: npm install -g pyright
-      - name: Lint
-        run: make lint
-
-  test:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-    strategy:
-      max-parallel: 10
-      matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-        os: [ubuntu-latest , macos-latest]
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: ./.github/actions/cache
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev,plugin]
-          make dev
-      - name: Test
-        run: make test
-      - name: Test pyarrow in Linux
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: make test_arrow
-
   build:
     name: "Build PyPI Package"
     runs-on: ${{ matrix.os }}
@@ -86,7 +35,7 @@ jobs:
   publish:
     name: "Publish PyPI Package"
     runs-on: ubuntu-latest
-    needs: [lint,test,build]
+    needs: [build]
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Since we have the merge queue, it can guarantee that the merged commits are correct.