### PR TITLE
chore: use absolute import path

### DIFF
--- a/mosec/__init__.py
+++ b/mosec/__init__.py
@@ -14,19 +14,19 @@
 
 """MOSEC is a machine learning model serving framework."""
 
-from .errors import (
+from mosec.errors import (
     ClientError,
     DecodingError,
     EncodingError,
     ServerError,
     ValidationError,
 )
-from .log import get_logger
-from .server import Server
-from .worker import Worker
+from mosec.log import get_logger
+from mosec.server import Server
+from mosec.worker import Worker
 
 try:
-    from ._version import __version__  # type: ignore
+    from mosec._version import __version__  # type: ignore
 except ImportError:
     from setuptools_scm import get_version  # type: ignore
 

--- a/mosec/args.py
+++ b/mosec/args.py
@@ -28,7 +28,7 @@ import socket
 import tempfile
 import warnings
 
-from .env import get_env_namespace
+from mosec.env import get_env_namespace
 
 
 def is_port_available(addr: str, port: int) -> bool:

--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -23,11 +23,11 @@ import traceback
 from multiprocessing.synchronize import Event
 from typing import Any, Callable, Optional, Sequence, Tuple, Type
 
-from .errors import MosecError
-from .ipc import IPCWrapper
-from .log import get_logger
-from .protocol import HTTPStautsCode, Protocol
-from .worker import Worker
+from mosec.errors import MosecError
+from mosec.ipc import IPCWrapper
+from mosec.log import get_logger
+from mosec.protocol import HTTPStautsCode, Protocol
+from mosec.worker import Worker
 
 logger = get_logger()
 

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -23,9 +23,9 @@ import time
 from multiprocessing.context import SpawnContext, SpawnProcess
 from typing import TYPE_CHECKING, Dict, List
 
-from .env import env_var_context
-from .log import get_logger
-from .worker import Worker
+from mosec.env import env_var_context
+from mosec.log import get_logger
+from mosec.worker import Worker
 
 if TYPE_CHECKING:
     from multiprocessing.connection import PipeConnection  # type: ignore

--- a/mosec/errors.py
+++ b/mosec/errors.py
@@ -23,7 +23,7 @@ is raised; if the decoded data cannot pass the validation check (usually
 implemented by users), the `ValidationError` should be raised.
 """
 
-from .protocol import HTTPStautsCode
+from mosec.protocol import HTTPStautsCode
 
 
 class MosecError(Exception):

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -22,7 +22,7 @@ import os
 from datetime import datetime
 from typing import Any, MutableMapping
 
-from .args import mosec_args
+from mosec.args import mosec_args
 
 MOSEC_LOG_NAME = __name__
 

--- a/mosec/mixin/__init__.py
+++ b/mosec/mixin/__init__.py
@@ -14,7 +14,7 @@
 
 """Provide useful mixin to extend MOSEC."""
 
-from .msgpack_worker import MsgpackMixin
-from .numbin_worker import NumBinIPCMixin
+from mosec.mixin.msgpack_worker import MsgpackMixin
+from mosec.mixin.numbin_worker import NumBinIPCMixin
 
 __all__ = ["MsgpackMixin", "NumBinIPCMixin"]

--- a/mosec/mixin/msgpack_worker.py
+++ b/mosec/mixin/msgpack_worker.py
@@ -24,7 +24,7 @@ Features:
 import warnings
 from typing import Any
 
-from ..errors import DecodingError, EncodingError
+from mosec.errors import DecodingError, EncodingError
 
 try:
     import msgpack  # type: ignore

--- a/mosec/mixin/numbin_worker.py
+++ b/mosec/mixin/numbin_worker.py
@@ -25,7 +25,7 @@ Attention: numbin only supports NumPy ndarray types.
 import warnings
 from typing import Any
 
-from ..errors import DecodingError, EncodingError
+from mosec.errors import DecodingError, EncodingError
 
 try:
     import numbin as nb  # type: ignore

--- a/mosec/plugins/__init__.py
+++ b/mosec/plugins/__init__.py
@@ -14,6 +14,6 @@
 
 """Provide useful tools to extend MOSEC."""
 
-from .plasma_shm import PlasmaShmWrapper
+from mosec.plugins.plasma_shm import PlasmaShmWrapper
 
 __all__ = ["PlasmaShmWrapper"]

--- a/mosec/plugins/plasma_shm.py
+++ b/mosec/plugins/plasma_shm.py
@@ -24,7 +24,7 @@ sent via the original way.
 import warnings
 from typing import TYPE_CHECKING, List
 
-from ..ipc import IPCWrapper
+from mosec.ipc import IPCWrapper
 
 # We do not enforce the installation of third party libraries for
 # plugins, because users may not enable them.

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -22,7 +22,7 @@ from enum import IntFlag
 from io import BytesIO
 from typing import Sequence, Tuple
 
-from .log import get_logger
+from mosec.log import get_logger
 
 logger = get_logger()
 

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -52,13 +52,13 @@ from typing import Dict, List, Optional, Type, Union
 
 import pkg_resources
 
-from .args import mosec_args
-from .coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
-from .dry_run import DryRunner
-from .env import env_var_context
-from .ipc import IPCWrapper
-from .log import get_logger
-from .worker import Worker
+from mosec.args import mosec_args
+from mosec.coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
+from mosec.dry_run import DryRunner
+from mosec.env import env_var_context
+from mosec.ipc import IPCWrapper
+from mosec.log import get_logger
+from mosec.worker import Worker
 
 logger = get_logger()
 

--- a/mosec/worker.py
+++ b/mosec/worker.py
@@ -27,7 +27,7 @@ import json
 import pickle
 from typing import Any, Sequence
 
-from .errors import DecodingError, EncodingError
+from mosec.errors import DecodingError, EncodingError
 
 
 class Worker(abc.ABC):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -32,8 +32,7 @@ from mosec.coordinator import PROTOCOL_TIMEOUT, STAGE_EGRESS, STAGE_INGRESS, Coo
 from mosec.mixin import MsgpackMixin
 from mosec.protocol import HTTPStautsCode, _recv_all
 from mosec.worker import Worker
-
-from .utils import imitate_controller_send
+from tests.utils import imitate_controller_send
 
 socket_prefix = join(tempfile.gettempdir(), "test-mosec")
 stage = STAGE_INGRESS + STAGE_EGRESS

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -21,9 +21,8 @@ from typing import List
 import pytest
 
 from mosec.protocol import Protocol
-
-from .mock_socket import socket
-from .utils import imitate_controller_send
+from tests.mock_socket import socket
+from tests.utils import imitate_controller_send
 
 
 def echo(p: Protocol, datum: List[bytes]):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ import struct
 from socket import socket
 from typing import List, Union
 
-from .mock_socket import socket as mock_socket
+from tests.mock_socket import socket as mock_socket
 
 
 def imitate_controller_send(sock: Union[mock_socket, socket], l_data: List[bytes]):


### PR DESCRIPTION
https://peps.python.org/pep-0008/#imports

Absolute import path is recommended as long as it is not too verbose, for readability.