### PR TITLE
Add prefix to differentiate Mosec & user logs

### DIFF
--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -29,7 +29,7 @@ from mosec.log import get_logger
 from mosec.protocol import HTTPStautsCode, Protocol
 from mosec.worker import Worker
 
-logger = get_logger()
+logger = get_logger(True)
 
 
 CONN_MAX_RETRY = 10

--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -25,11 +25,11 @@ from typing import Any, Callable, Optional, Sequence, Tuple, Type
 
 from mosec.errors import MosecError
 from mosec.ipc import IPCWrapper
-from mosec.log import get_logger
+from mosec.log import get_internal_logger
 from mosec.protocol import HTTPStautsCode, Protocol
 from mosec.worker import Worker
 
-logger = get_logger(True)
+logger = get_internal_logger()
 
 
 CONN_MAX_RETRY = 10

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -24,14 +24,14 @@ from multiprocessing.context import SpawnContext, SpawnProcess
 from typing import TYPE_CHECKING, Dict, List
 
 from mosec.env import env_var_context
-from mosec.log import get_logger
+from mosec.log import get_internal_logger
 from mosec.worker import Worker
 
 if TYPE_CHECKING:
     from multiprocessing.connection import PipeConnection  # type: ignore
     from multiprocessing.synchronize import Event
 
-logger = get_logger(True)
+logger = get_internal_logger()
 
 
 def dry_run_func(

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from multiprocessing.connection import PipeConnection  # type: ignore
     from multiprocessing.synchronize import Event
 
-logger = get_logger()
+logger = get_logger(True)
 
 
 def dry_run_func(

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -65,6 +65,7 @@ class DebugFormat(MosecFormat):
         Args:
             fmt (str): logging message format (% style)
             datefmt (str): datatime format
+            prefix (str): prefix of target
         """
         # partially align with rust tracing_subscriber
         self.colors = {
@@ -98,6 +99,13 @@ class JSONFormat(MosecFormat):
     def __init__(
         self, fmt: str | None = None, datefmt: str | None = None, prefix: str = ""
     ) -> None:
+        """Init with `%` style format.
+
+        Args:
+            fmt (str): logging message format (% style)
+            datefmt (str): datatime format
+            prefix (str): prefix of target
+        """
         super().__init__(fmt, datefmt, "%")
         self.prefix = prefix
 

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -154,7 +154,7 @@ def use_json_log(level: int = logging.INFO, prefix: str = "", logger_name: str =
 
 
 def get_logger():
-    """Get the logger used by mosec for multiprocessing."""
+    """Get the logger used by mosec user for multiprocessing."""
     prefix = USER_LOG_PREFIX
     logger_name = USER_LOG_NAME
     if os.environ.get(MOSEC_LOG_NAME, "") == str(logging.DEBUG):
@@ -163,6 +163,7 @@ def get_logger():
 
 
 def get_internal_logger():
+    """Get the logger used by mosec internally for multiprocessing."""
     prefix = MOSEC_LOG_PREFIX
     logger_name = MOSEC_LOG_NAME
     if os.environ.get(MOSEC_LOG_NAME, "") == str(logging.DEBUG):

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -24,7 +24,7 @@ from typing import Sequence, Tuple
 
 from mosec.log import get_logger
 
-logger = get_logger()
+logger = get_logger(True)
 
 IPC_LARGE_DATA_SIZE = 1024 * 1024  # set as 1 MB
 

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -22,9 +22,9 @@ from enum import IntFlag
 from io import BytesIO
 from typing import Sequence, Tuple
 
-from mosec.log import get_logger
+from mosec.log import get_internal_logger
 
-logger = get_logger(True)
+logger = get_internal_logger()
 
 IPC_LARGE_DATA_SIZE = 1024 * 1024  # set as 1 MB
 

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -60,7 +60,7 @@ from mosec.ipc import IPCWrapper
 from mosec.log import get_logger
 from mosec.worker import Worker
 
-logger = get_logger()
+logger = get_logger(True)
 
 
 GUARD_CHECK_INTERVAL = 1

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -57,10 +57,10 @@ from mosec.coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
 from mosec.dry_run import DryRunner
 from mosec.env import env_var_context
 from mosec.ipc import IPCWrapper
-from mosec.log import get_logger
+from mosec.log import get_internal_logger
 from mosec.worker import Worker
 
-logger = get_logger(True)
+logger = get_internal_logger()
 
 
 GUARD_CHECK_INTERVAL = 1


### PR DESCRIPTION
Fix Issue #289 

Before:
It's hard to differentiate logs from user, mosec python,mosec rust.  
```bash
{"timestamp": "2023-03-23T 14:50 : 33.244310+0800", "level": "INFO", "fields": {"message": "Starting server"}, "target": "main. py:<module>"}
{"timestamp": "2023-03-23T 14:50 : 36.199222+0800", "level": "INFO", "fields": {"message": "<3|Postprocess|2> socket connected to /tmp/mosec_e19e5a63/ipc_3. socket"}, "target": "protocol. py: open"}
{"timestamp": "2023-03-23T 14:50 : 36.199435642+ 08:00 ","level": "INFO","fields":{"message": "socket accepted connection from","addr": " (unnamed)"},"target": "mosec:: protocol"}
```

After:
logs field `target` from user startwith 'user::'.
logs field `target` from mosec python and mosec rust startwith 'mosec::'

```bash
{"timestamp": "2023-03-23T 15:00 : 24.894625+0800", "level": "INFO", "fields": {"message": "Starting server"}, "target": "user:: main. py:<module>"}
{"timestamp": "2023-03-23T 15:00 : 28.164207+0800", "level": "INFO", "fields": {"message": "<3|Postprocess|1> socket connected to /tmp/mosec_cd3a0f7c/ipc_3. socket"}, "target": "mosec:: protocol. py: open"}
{"timestamp": "2023-03-23T 15:00 : 28.16442719+ 08:00 ","level": "INFO","fields":{"message": "socket accepted connection from","addr": " (unnamed)"},"target": "mosec:: protocol"}
```