### PR TITLE
feat: Set timeout for worker.forward

### DIFF
--- a/mosec/errors.py
+++ b/mosec/errors.py
@@ -102,3 +102,22 @@ class ValidationError(MosecError):
 
     code = HTTPStautsCode.VALIDATION_ERROR
     msg = "request validation error"
+
+
+class MosecTimeoutError(BaseException):
+    """Exception raised when a MOSEC worker operation times out.
+
+    If a bug in the forward code causes the worker to hang indefinitely, a timeout
+    can be used to ensure that the worker eventually returns control to the main
+    thread program. When a timeout occurs, the `MosecTimeout` exception is raised.
+    This exception can be caught and handled appropriately to perform any necessary
+    cleanup tasks or return a response indicating that the operation timed out.
+
+    Note that `MosecTimeout` is a subclass of `BaseException`, not `Exception`.
+    This is because timeouts should not be caught and handled in the same way as
+    other exceptions. Instead, they should be handled in a separate `except` block
+    which isn't designed to break the working loop.
+    """
+
+    code = HTTPStautsCode.TIMEOUT_ERROR
+    msg = "mosec timeout error"

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -36,6 +36,7 @@ class HTTPStautsCode(IntFlag):
     BAD_REQUEST = 2  # 400
     VALIDATION_ERROR = 4  # 422
     INTERNAL_ERROR = 8  # 500
+    TIMEOUT_ERROR = 16  # 408
 
 
 class Protocol:

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -90,7 +90,7 @@ class Server:
         self._worker_num: List[int] = []
         self._worker_mbs: List[int] = []
         self._worker_wait: List[int] = []
-        self._worker_timeout: List[float] = []
+        self._worker_timeout: List[int] = []
 
         self._coordinator_env: List[Union[None, List[Dict[str, str]]]] = []
         self._coordinator_ctx: List[str] = []

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -90,6 +90,7 @@ class Server:
         self._worker_num: List[int] = []
         self._worker_mbs: List[int] = []
         self._worker_wait: List[int] = []
+        self._worker_timeout: List[float] = []
 
         self._coordinator_env: List[Union[None, List[Dict[str, str]]]] = []
         self._coordinator_ctx: List[str] = []
@@ -123,6 +124,7 @@ class Server:
         max_wait_time,
         start_method,
         env,
+        timeout,
     ):
         def validate_int_ge(number, name, threshold=1):
             assert isinstance(
@@ -153,6 +155,7 @@ class Server:
         validate_int_ge(num, "worker number")
         validate_int_ge(max_batch_size, "maximum batch size")
         validate_int_ge(max_wait_time, "maximum wait time", 0)
+        validate_int_ge(timeout, "forward timeout", 0)
         assert (
             start_method in NEW_PROCESS_METHOD
         ), f"start method must be one of {NEW_PROCESS_METHOD}"
@@ -213,11 +216,12 @@ class Server:
     def _manage_coordinators(self):
         first = True
         while not self._server_shutdown:
-            for stage_id, (w_cls, w_num, w_mbs, c_ctx, c_env) in enumerate(
+            for stage_id, (w_cls, w_num, w_mbs, w_timeout, c_ctx, c_env) in enumerate(
                 zip(
                     self._worker_cls,
                     self._worker_num,
                     self._worker_mbs,
+                    self._worker_timeout,
                     self._coordinator_ctx,
                     self._coordinator_env,
                 )
@@ -263,6 +267,7 @@ class Server:
                             stage_id + 1,
                             worker_id + 1,
                             self.ipc_wrapper,
+                            w_timeout,
                         ),
                         daemon=True,
                     )
@@ -316,6 +321,7 @@ class Server:
         ), f"{type(proc)} is not a process or subprocess"
         self._daemon[name] = proc
 
+    # pylint: disable=too-many-arguments
     def append_worker(
         self,
         worker: Type[Worker],
@@ -324,6 +330,7 @@ class Server:
         max_wait_time: int = 0,
         start_method: str = "spawn",
         env: Union[None, List[Dict[str, str]]] = None,
+        timeout: int = 0,
     ):
         """Sequentially appends workers to the workflow pipeline.
 
@@ -338,14 +345,18 @@ class Server:
                 configure, will use the CLI argument `--wait` (default=10ms)
             start_method: the process starting method ("spawn" or "fork")
             env: the environment variables to set before starting the process
+            timeout: the timeout (second) for each worker forward processing (>=1)
         """
         self._validate_arguments(
-            worker, num, max_batch_size, max_wait_time, start_method, env
+            worker, num, max_batch_size, max_wait_time, start_method, env, timeout
         )
         self._worker_cls.append(worker)
         self._worker_num.append(num)
         self._worker_mbs.append(max_batch_size)
         self._worker_wait.append(max_wait_time)
+        self._worker_timeout.append(
+            timeout if timeout >= 1 else self._configs["timeout"] // 1000
+        )
         self._coordinator_env.append(env)
         self._coordinator_ctx.append(start_method)
         self._coordinator_pools.append([None] * num)

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ async fn inference(req: Request<Body>) -> Response<Body> {
                 }
                 TaskCode::BadRequestError => StatusCode::BAD_REQUEST,
                 TaskCode::ValidationError => StatusCode::UNPROCESSABLE_ENTITY,
+                TaskCode::TimeoutError => StatusCode::REQUEST_TIMEOUT,
                 TaskCode::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
             }
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -34,6 +34,7 @@ const LENGTH_U8_SIZE: usize = 4;
 const BIT_STATUS_OK: u16 = 0b1;
 const BIT_STATUS_BAD_REQ: u16 = 0b10;
 const BIT_STATUS_VALIDATION_ERR: u16 = 0b100;
+const BIT_STATUS_TIMEOUT_ERR: u16 = 0b10000;
 // Others are treated as Internal Error
 
 #[allow(clippy::too_many_arguments)]
@@ -168,6 +169,8 @@ async fn read_message(
         TaskCode::BadRequestError
     } else if flag & BIT_STATUS_VALIDATION_ERR > 0 {
         TaskCode::ValidationError
+    } else if flag & BIT_STATUS_TIMEOUT_ERR > 0 {
+        TaskCode::TimeoutError
     } else {
         TaskCode::InternalError
     };

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -31,6 +31,7 @@ pub(crate) enum TaskCode {
     Normal,
     BadRequestError,
     ValidationError,
+    TimeoutError,
     InternalError,
 }
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -76,6 +76,7 @@ def base_test_config():
         "stage_id": 1,
         "worker_id": 1,
         "c_ctx": "spawn",
+        "timeout": 3,
     }
 
 
@@ -91,6 +92,7 @@ def test_coordinator_worker_property():
         stage_id=2,
         worker_id=3,
         ipc_wrapper=None,
+        timeout=3,
     )
     assert c.worker.stage == STAGE_EGRESS
     assert c.worker.worker_id == 3
@@ -110,6 +112,7 @@ def make_coordinator_process(w_cls, c_ctx, shutdown, shutdown_notify, config):
             config["stage_id"],
             config["worker_id"],
             None,
+            config["timeout"],
         ),
         daemon=True,
     )

--- a/tests/test_timeout_service.py
+++ b/tests/test_timeout_service.py
@@ -1,0 +1,100 @@
+# Copyright 2023 MOSEC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import random
+import shlex
+import socket
+import subprocess
+import time
+from typing import Any, Type
+
+import httpx
+import pytest
+
+from mosec import Worker
+
+
+def wait_for_port_open(host: str, port: int, timeout: int):
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect((host, port))
+            sock.shutdown(socket.SHUT_RDWR)
+            return True
+        except (ConnectionRefusedError, OSError):
+            pass
+        finally:
+            sock.close()
+        time.sleep(0.1)
+    return False
+
+
+def wait_for_port_free(host: str, port: int, timeout: int):
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect((host, port))
+            sock.shutdown(socket.SHUT_RDWR)
+        except ConnectionRefusedError:
+            return True
+        finally:
+            sock.close()
+        time.sleep(0.1)
+    return False
+
+
+@pytest.mark.parametrize(
+    "worker_cls,server_timeout,status_code,port",
+    [
+        ("SleepyInference1", 1, 408, 8000),
+        ("SleepyInference1", 2, 200, 8001),
+        ("SleepyInference2", 2, 408, 8002),
+        ("SleepyInference4", 5, 408, 8003),
+    ],
+)
+def test_forward_timeout(
+    worker_cls: Type[Worker], server_timeout: int, status_code: int, port: int
+):
+    p = subprocess.Popen(
+        shlex.split(
+            f"python -u tests/timeout_service.py --worker_cls {worker_cls} --server_timeout {server_timeout} --status_code {status_code} --port {port}"
+        )
+    )
+    assert (
+        wait_for_port_open("127.0.0.1", port, 30) is True
+    ), "service failed to start in 30s"
+    input_data = [random.randint(-99, 99)]
+    response = httpx.post(
+        f"http://localhost:{port}/inference",
+        json={"array": input_data},
+    )
+    assert response.status_code == status_code
+    p.terminate()
+    assert (
+        wait_for_port_free("127.0.0.1", port, 30) is True
+    ), "service failed to terminate in 30s"
+
+
+if __name__ == "__main__":
+    params = [
+        ("SleepyInference1", 1, 408, 8000),
+        ("SleepyInference1", 2, 200, 8001),
+        ("SleepyInference2", 2, 408, 8002),
+        ("SleepyInference4", 5, 408, 8003),
+    ]
+    for param in params:
+        test_forward_timeout(*param)

--- a/tests/test_timeout_service.py
+++ b/tests/test_timeout_service.py
@@ -63,7 +63,6 @@ def wait_for_port_free(host: str, port: int, timeout: int):
     [
         (1.9, 1, HTTPStatus.REQUEST_TIMEOUT, 8000),
         (1.9, 2, HTTPStatus.OK, 8001),
-        (2, 2, HTTPStatus.REQUEST_TIMEOUT, 8002),
         (4, 5, HTTPStatus.REQUEST_TIMEOUT, 8003),
     ],
 )

--- a/tests/test_timeout_service.py
+++ b/tests/test_timeout_service.py
@@ -59,26 +59,26 @@ def wait_for_port_free(host: str, port: int, timeout: int):
 
 
 @pytest.mark.parametrize(
-    "worker_cls,server_timeout,status_code,port",
+    "worker_timeout,server_timeout,status_code,port",
     [
-        ("SleepyInference1", 1, HTTPStatus.REQUEST_TIMEOUT, 8000),
-        ("SleepyInference1", 2, HTTPStatus.OK, 8001),
-        ("SleepyInference2", 2, HTTPStatus.REQUEST_TIMEOUT, 8002),
-        ("SleepyInference4", 5, HTTPStatus.REQUEST_TIMEOUT, 8003),
+        (1.9, 1, HTTPStatus.REQUEST_TIMEOUT, 8000),
+        (1.9, 2, HTTPStatus.OK, 8001),
+        (2, 2, HTTPStatus.REQUEST_TIMEOUT, 8002),
+        (4, 5, HTTPStatus.REQUEST_TIMEOUT, 8003),
     ],
 )
 def test_forward_timeout(
-    worker_cls: Type[Worker], server_timeout: int, status_code: int, port: int
+    worker_timeout: float, server_timeout: int, status_code: int, port: int
 ):
     p = subprocess.Popen(
         shlex.split(
-            f"python -u tests/timeout_service.py --worker_cls {worker_cls}"
-            + f" --server_timeout {server_timeout} --status_code {status_code} --port {port}"
+            f"python -u tests/timeout_service.py --worker_timeout {worker_timeout}"
+            + f" --server_timeout {server_timeout}  --port {port}"
         )
     )
     assert (
-        wait_for_port_open("127.0.0.1", port, 30) is True
-    ), "service failed to start in 30s"
+        wait_for_port_open("127.0.0.1", port, 5) is True
+    ), "service failed to start in 5s"
     input_data = [random.randint(-99, 99)]
     response = httpx.post(
         f"http://localhost:{port}/inference",

--- a/tests/test_timeout_service.py
+++ b/tests/test_timeout_service.py
@@ -72,7 +72,7 @@ def test_forward_timeout(
     p = subprocess.Popen(
         shlex.split(
             f"python -u tests/timeout_service.py --worker_timeout {worker_timeout}"
-            + f" --server_timeout {server_timeout}  --port {port}"
+            f" --server_timeout {server_timeout}  --port {port}"
         )
     )
     assert (

--- a/tests/test_timeout_service.py
+++ b/tests/test_timeout_service.py
@@ -43,21 +43,6 @@ def wait_for_port_open(host: str, port: int, timeout: int):
     return False
 
 
-def wait_for_port_free(host: str, port: int, timeout: int):
-    start_time = time.monotonic()
-    while time.monotonic() - start_time < timeout:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            sock.connect((host, port))
-            sock.shutdown(socket.SHUT_RDWR)
-        except ConnectionRefusedError:
-            return True
-        finally:
-            sock.close()
-        time.sleep(0.1)
-    return False
-
-
 @pytest.mark.parametrize(
     "worker_timeout,server_timeout,status_code,port",
     [

--- a/tests/timeout_service.py
+++ b/tests/timeout_service.py
@@ -1,0 +1,81 @@
+# Copyright 2023 MOSEC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import multiprocessing
+import random
+import shlex
+import socket
+import subprocess
+import time
+from typing import Any, Type
+
+import httpx
+import pytest
+
+from mosec import Server, Worker
+
+
+class SleepyInference1(Worker):
+    """Sample Class."""
+
+    def forward(self, data: Any) -> Any:
+        time.sleep(1.9)
+        return data
+
+
+class SleepyInference2(Worker):
+    """Sample Class."""
+
+    def forward(self, data: Any) -> Any:
+        time.sleep(2)
+        return data
+
+
+class SleepyInference4(Worker):
+    """Sample Class."""
+
+    def forward(self, data: Any) -> Any:
+        time.sleep(4)
+        return data
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+
+    # 添加参数
+    parser.add_argument("--worker_cls", type=str, help="worker class name")
+    parser.add_argument("--server_timeout", type=int, help="server timeout")
+    parser.add_argument("--status_code", type=int, help="status code")
+    parser.add_argument("--port", type=int, help="port")
+
+    # 解析命令行参数
+    args = parser.parse_args()
+
+    # 获取参数值
+    worker_cls = args.worker_cls
+    server_timeout = args.server_timeout
+    status_code = args.status_code
+
+    if worker_cls == "SleepyInference1":
+        worker_cls = SleepyInference1
+    elif worker_cls == "SleepyInference2":
+        worker_cls = SleepyInference2
+    elif worker_cls == "SleepyInference4":
+        worker_cls = SleepyInference4
+    server = Server()
+    server.append_worker(worker_cls, timeout=server_timeout)
+    server.run()

--- a/tests/timeout_service.py
+++ b/tests/timeout_service.py
@@ -56,16 +56,13 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
 
-    # 添加参数
     parser.add_argument("--worker_cls", type=str, help="worker class name")
     parser.add_argument("--server_timeout", type=int, help="server timeout")
     parser.add_argument("--status_code", type=int, help="status code")
     parser.add_argument("--port", type=int, help="port")
 
-    # 解析命令行参数
     args = parser.parse_args()
 
-    # 获取参数值
     worker_cls = args.worker_cls
     server_timeout = args.server_timeout
     status_code = args.status_code


### PR DESCRIPTION
refer to [feat: raise TimeoutError when the forward doesn't return in a long time #298](https://github.com/mosecorg/mosec/issues/298)

raise MosecTimeoutError when the forward doesn't return in a long time.
Since there's already a TimeoutError inherited from OSError in python stdlib, I use `MosecTimeoutError` instead of `TimeoutError`.

## Before:
Unable to set timer for `worker.forward` function, it may block that worker. 
In Rust side, there's a `ServiceError::Timeout` error to detect if the worker runs too long.

## After:
Developers can set timeout for workers of each stage like `server.append_worker(Inference, timeout=2)`.
If `worker.forward` runs too long, it will raise MosecTimeoutError, send 408 request timeout error to Rust side.

In response.text, users can see  `408 mosec timeout error: 'forward' timeout after 2s` 

In log, developers can see
```bash
{"timestamp": "2023-04-02T12:53:57.918122+0800", "level": "INFO", "fields": {"message": "<2|Inference|1> mosec timeout error: `forward` timeout after 2s"}, "target": "mosec::coordinator.py:coordinate"}
{"timestamp":"2023-04-02T12:53:57.919043247+08:00","level":"WARN","fields":{"message":"abnormal tasks, check Python log for more details","ids":"[1]","code":"TimeoutError"},"target":"mosec::protocol"}
```