### PR TITLE
feat: add monitoring demo

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+http://localhost
+https://localhost

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,2 @@
-http://localhost
-https://localhost
+http://127.0.0.1
+https://127.0.0.1

--- a/examples/monitor/docker-compose.yml
+++ b/examples/monitor/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+services:
+
+  mosec:
+    image: python:3.9-slim-buster
+    container_name: mosec
+    ports:
+      - "8000:8000"
+      - "5000:5000"
+    volumes:
+      - ../python_side_metrics.py:/root/python_side_metrics.py
+    entrypoint: ["/bin/bash", "-c","pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -U mosec prometheus_client && python /root/python_side_metrics.py"]
+    restart: always
+
+
+  prometheus:
+    image: prom/prometheus:v2.30.0
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    restart: always
+    depends_on:
+      - mosec
+
+  grafana:
+    image: grafana/grafana:8.2.2
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./mosec_datasource.yml:/etc/grafana/provisioning/datasources/mosec_datasource.yml
+      - ./mosec_dashboard.yml:/etc/grafana/provisioning/dashboards/mosec_dashboard.yml
+      - ./mosec_dashboard.json:/etc/grafana/provisioning/dashboards/mosec_dashboard.json
+    restart: always
+    depends_on:
+      - prometheus

--- a/examples/monitor/docker-compose.yml
+++ b/examples/monitor/docker-compose.yml
@@ -3,16 +3,11 @@ version: '3'
 services:
 
   mosec:
-    image: python:3.9-slim-buster
+    image: mosec
     container_name: mosec
     ports:
       - "8000:8000"
       - "5000:5000"
-    volumes:
-      - ../python_side_metrics.py:/root/python_side_metrics.py
-    entrypoint: ["/bin/bash", "-c","pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -U mosec prometheus_client && python /root/python_side_metrics.py"]
-    restart: always
-
 
   prometheus:
     image: prom/prometheus:v2.30.0

--- a/examples/monitor/docker-compose.yml
+++ b/examples/monitor/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   mosec:
-    image: mosec
+    build: .
     container_name: mosec
     ports:
       - "8000:8000"

--- a/examples/monitor/dockerfile
+++ b/examples/monitor/dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-slim-buster
+
+COPY python_side_metrics.py /root/python_side_metrics.py
+
+RUN pip install -U mosec prometheus_client
+
+ENTRYPOINT ["bash", "-c", "python /root/python_side_metrics.py"]
+
+EXPOSE 8000 5000

--- a/examples/monitor/dockerfile
+++ b/examples/monitor/dockerfile
@@ -4,6 +4,6 @@ COPY python_side_metrics.py /root/python_side_metrics.py
 
 RUN pip install -U mosec prometheus_client
 
-ENTRYPOINT ["bash", "-c", "python /root/python_side_metrics.py"]
+ENTRYPOINT ["python", "/root/python_side_metrics.py"]
 
 EXPOSE 8000 5000

--- a/examples/monitor/mosec_dashboard.json
+++ b/examples/monitor/mosec_dashboard.json
@@ -1,0 +1,453 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": "Prometheus",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "id": 8,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                },
+                "tooltip": {
+                    "mode": "single"
+                }
+            },
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "scrape_duration_seconds",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Scrape Duration Seconds",
+            "type": "timeseries"
+        },
+        {
+            "datasource": "Prometheus",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisGridShow": true,
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                },
+                "tooltip": {
+                    "mode": "single"
+                }
+            },
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "mosec_service_throughput",
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Mosec Service Throughput",
+            "type": "timeseries"
+        },
+        {
+            "datasource": "Prometheus",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 4,
+                        "pointSize": 8,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 8
+            },
+            "id": 6,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                },
+                "tooltip": {
+                    "mode": "single"
+                }
+            },
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "mosec_service_remaining_task",
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Remaining Task",
+            "type": "timeseries"
+        },
+        {
+            "datasource": "Prometheus",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 9
+            },
+            "id": 10,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                },
+                "tooltip": {
+                    "mode": "single"
+                }
+            },
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "inference_result_total",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Inference Result Total",
+            "type": "timeseries"
+        },
+        {
+            "datasource": "Prometheus",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 16
+            },
+            "id": 4,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom"
+                },
+                "tooltip": {
+                    "mode": "single"
+                }
+            },
+            "targets": [
+                {
+                    "exemplar": true,
+                    "expr": "mosec_service_batch_size_count",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "title": "Batch Size Count",
+            "type": "timeseries"
+        }
+    ],
+    "schemaVersion": 31,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": []
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Mosec",
+    "uid": "4vV0bzE4z",
+    "version": 1
+}

--- a/examples/monitor/mosec_dashboard.yml
+++ b/examples/monitor/mosec_dashboard.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+ 
+providers:
+  - name: 'Mosec Dashboards'
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/examples/monitor/mosec_datasource.yml
+++ b/examples/monitor/mosec_datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+  - name: 'Prometheus'
+    type: prometheus
+    access: proxy
+    url: prometheus:9090

--- a/examples/monitor/prometheus.yml
+++ b/examples/monitor/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval:     1s
+  evaluation_interval: 1s
+
+scrape_configs:
+  - job_name: mosec_rust
+    static_configs:
+      - targets: ['mosec:8000']
+  - job_name: mosec_python
+    static_configs:
+      - targets: ['mosec:5000']
+  - job_name: prometheus
+    static_configs:
+      - targets: ['prometheus:9090']

--- a/examples/monitor/python_side_metrics.py
+++ b/examples/monitor/python_side_metrics.py
@@ -1,0 +1,82 @@
+# Copyright 2022 MOSEC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Example: Adding metrics service."""
+
+import os
+import pathlib
+import tempfile
+from typing import List
+
+from prometheus_client import (  # type: ignore
+    CollectorRegistry,
+    Counter,
+    multiprocess,
+    start_http_server,
+)
+
+from mosec import Server, ValidationError, Worker, get_logger
+
+logger = get_logger()
+
+
+# check the PROMETHEUS_MULTIPROC_DIR environment variable before import Prometheus
+if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+    metric_dir_path = os.path.join(tempfile.gettempdir(), "prometheus_multiproc_dir")
+    pathlib.Path(metric_dir_path).mkdir(parents=True, exist_ok=True)
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = metric_dir_path
+
+
+metric_registry = CollectorRegistry()
+multiprocess.MultiProcessCollector(metric_registry)
+counter = Counter(
+    "inference_result",
+    "statistic of result",
+    ("status", "worker_id"),
+    registry=metric_registry,
+)
+
+
+class Inference(Worker):
+    """Sample Inference Worker."""
+
+    def __init__(self):
+        super().__init__()
+        self.worker_id = str(self.worker_id)
+
+    def deserialize(self, data: bytes) -> int:
+        json_data = super().deserialize(data)
+        try:
+            res = int(json_data.get("num"))
+        except Exception as err:
+            raise ValidationError(err) from err
+        return res
+
+    def forward(self, data: List[int]) -> List[bool]:
+        avg = sum(data) / len(data)
+        ans = [x >= avg for x in data]
+        counter.labels(status="true", worker_id=self.worker_id).inc(sum(ans))
+        counter.labels(status="false", worker_id=self.worker_id).inc(
+            len(ans) - sum(ans)
+        )
+        return ans
+
+
+if __name__ == "__main__":
+    # Run the metrics server in another thread.
+    start_http_server(5000, registry=metric_registry)
+
+    # Run the inference server
+    server = Server()
+    server.append_worker(Inference, num=2, max_batch_size=8)
+    server.run()

--- a/examples/monitor/readme.md
+++ b/examples/monitor/readme.md
@@ -15,6 +15,11 @@ Navigate to the directory containing the docker-compose.yaml file:
 cd mosec/examples/monitor
 ```
 
+Build metrics example image of mosec configured in `dockerfile` :
+```bash
+docker build -t mosec .
+```
+
 Start the monitoring system by running the following command:
 ```bash
 docker-compose up -d
@@ -22,11 +27,17 @@ docker-compose up -d
 This command will start three containers: Mosec, Prometheus, and Grafana.
 
 
+# Test
+Run test and feed metrics to Prometheus.
+```shell
+http POST :8000/inference num=1
+```
+
 # Accessing Prometheus
-Prometheus is a monitoring and alerting system that collects metrics from Mosec. You can access the Prometheus UI by visiting http://localhost:9090 in your web browser.
+Prometheus is a monitoring and alerting system that collects metrics from Mosec. You can access the Prometheus UI by visiting http://127.0.0.1:9090 in your web browser.
 
 # Accessing Grafana
-Grafana is a visualization tool for monitoring and analyzing metrics. You can access the Grafana UI by visiting http://localhost:3000 in your web browser. The default username and password are both admin.
+Grafana is a visualization tool for monitoring and analyzing metrics. You can access the Grafana UI by visiting http://127.0.0.1:3000 in your web browser. The default username and password are both admin.
 
 # Stopping the monitoring system
 To stop the monitoring system, run the following command:

--- a/examples/monitor/readme.md
+++ b/examples/monitor/readme.md
@@ -15,11 +15,6 @@ Navigate to the directory containing the docker-compose.yaml file:
 cd mosec/examples/monitor
 ```
 
-Build metrics example image of mosec configured in `dockerfile` :
-```bash
-docker build -t mosec .
-```
-
 Start the monitoring system by running the following command:
 ```bash
 docker-compose up -d

--- a/examples/monitor/readme.md
+++ b/examples/monitor/readme.md
@@ -1,0 +1,37 @@
+# How to build monitoring system for Mosec
+In this tutorial, we will explain how to build monitoring system for Mosec, which includes Prometheus and Grafana.
+
+## Prerequisites
+Before starting, you need to have Docker and Docker Compose installed on your machine. If you don't have them installed, you can follow the instructions  [get-docker](https://docs.docker.com/get-docker/) and [compose](https://docs.docker.com/compose/install/) to install them.
+
+# Starting the monitoring system
+Clone the repository containing the docker-compose.yaml file:
+```bash
+git clone https://github.com/mosecorg/mosec.git
+```
+
+Navigate to the directory containing the docker-compose.yaml file:
+```bash
+cd mosec/examples/monitor
+```
+
+Start the monitoring system by running the following command:
+```bash
+docker-compose up -d
+```
+This command will start three containers: Mosec, Prometheus, and Grafana.
+
+
+# Accessing Prometheus
+Prometheus is a monitoring and alerting system that collects metrics from Mosec. You can access the Prometheus UI by visiting http://localhost:9090 in your web browser.
+
+# Accessing Grafana
+Grafana is a visualization tool for monitoring and analyzing metrics. You can access the Grafana UI by visiting http://localhost:3000 in your web browser. The default username and password are both admin.
+
+# Stopping the monitoring system
+To stop the monitoring system, run the following command:
+
+```bash
+docker-compose down
+```
+This command will stop and remove the containers created by Docker Compose.

--- a/examples/python_side_metrics.py
+++ b/examples/python_side_metrics.py
@@ -39,7 +39,12 @@ if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
 
 metric_registry = CollectorRegistry()
 multiprocess.MultiProcessCollector(metric_registry)
-counter = Counter("inference_result", "statistic of result", ("status", "worker_id"))
+counter = Counter(
+    "inference_result",
+    "statistic of result",
+    ("status", "worker_id"),
+    registry=metric_registry,
+)
 
 
 class Inference(Worker):
@@ -69,7 +74,7 @@ class Inference(Worker):
 
 if __name__ == "__main__":
     # Run the metrics server in another thread.
-    start_http_server(5000)
+    start_http_server(5000, registry=metric_registry)
 
     # Run the inference server
     server = Server()

--- a/examples/resnet50_server_msgpack.py
+++ b/examples/resnet50_server_msgpack.py
@@ -41,7 +41,7 @@ class Preprocess(MsgpackMixin, Worker):
             transforms.CenterCrop(224),
             transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
         )
-        self.transform = torch.jit.script(trans)
+        self.transform = torch.jit.script(trans)  # type: ignore
 
     def forward(self, data: dict):
         # Customized validation for input key and field content; raise
@@ -54,7 +54,7 @@ class Preprocess(MsgpackMixin, Worker):
             raise ValidationError(f"cannot decode as image data: {err}") from err
 
         tensor = transforms.ToTensor()(image)
-        data = self.transform(tensor)
+        data = self.transform(tensor)  # type: ignore
         return data
 
 


### PR DESCRIPTION
ref to #297

Provide a whole monitoring demo with Prometheus and Grafana.

# Usage

`cd examples/monitor` and run `docker-compose up`
Then you can open [Grafana](http://localhost:3000/d/4vV0bzE4z/mosec?orgId=1) to see the mosec dashboard
![image](https://user-images.githubusercontent.com/29254314/231960831-3194e0af-3ff5-4892-b088-6aa8a819a158.png)

or open [Prometheus](http://127.0.0.1:9090) to query the metrics collected in mosec.
![image](https://user-images.githubusercontent.com/29254314/231961226-ea85fada-7e9c-4476-bcb1-7237486a62dc.png)
