### PR TITLE
chore: only enable nightly test for Linux

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,12 +11,12 @@ concurrency:
 
 jobs:
   test:
-    name: "stress bad requests test"
+    name: "stressful bad requests test"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.11"
       - uses: ./.github/actions/cache
       - name: Install dependencies
         run: |


### PR DESCRIPTION
I have no idea what happened to macOS.