### PR TITLE
fix: plasma mixin should use super serde with shm storage

### DIFF
--- a/examples/plasma_shm_ipc.py
+++ b/examples/plasma_shm_ipc.py
@@ -33,10 +33,10 @@ class DataProducer(PlasmaShmIPCMixin, Worker):
 
     def forward(self, data: dict) -> np.ndarray:
         try:
-            data_bytes = np.random.rand(int(data["size"]))
+            nums = np.random.rand(int(data["size"]))
         except KeyError as err:
             raise ValidationError(err) from err
-        return data_bytes
+        return nums
 
 
 class DataConsumer(PlasmaShmIPCMixin, Worker):

--- a/examples/plasma_shm_ipc.py
+++ b/examples/plasma_shm_ipc.py
@@ -21,6 +21,7 @@ that when it exits the service is able to gracefully shutdown
 and restarted by the orchestrator.
 """
 
+import numpy as np
 from pyarrow import plasma  # type: ignore
 
 from mosec import Server, ValidationError, Worker
@@ -30,9 +31,9 @@ from mosec.mixin import PlasmaShmIPCMixin
 class DataProducer(PlasmaShmIPCMixin, Worker):
     """Sample Data Producer."""
 
-    def forward(self, data: dict) -> bytes:
+    def forward(self, data: dict) -> np.ndarray:
         try:
-            data_bytes = b"a" * int(data["size"])
+            data_bytes = np.random.rand(int(data["size"]))
         except KeyError as err:
             raise ValidationError(err) from err
         return data_bytes
@@ -41,8 +42,8 @@ class DataProducer(PlasmaShmIPCMixin, Worker):
 class DataConsumer(PlasmaShmIPCMixin, Worker):
     """Sample Data Consumer."""
 
-    def forward(self, data: bytes) -> dict:
-        return {"ipc test data length": len(data)}
+    def forward(self, data: np.ndarray) -> dict:
+        return {"ipc test data": data.tolist()}
 
 
 if __name__ == "__main__":

--- a/mosec/mixin/plasma_worker.py
+++ b/mosec/mixin/plasma_worker.py
@@ -74,13 +74,13 @@ class PlasmaShmIPCMixin(Worker):
     def serialize_ipc(self, data: Any) -> bytes:
         """Save the data to the plasma server and return the id."""
         client = self._get_client()
-        object_id = client.put(data)
+        object_id = client.put(super().serialize_ipc(data))
         return object_id.binary()
 
     def deserialize_ipc(self, data: bytes) -> Any:
         """Get the data from the plasma server and delete it."""
         client = self._get_client()
         object_id = plasma.ObjectID(bytes(data))
-        obj = client.get(object_id)
+        obj = super().deserialize_ipc(client.get(object_id))
         client.delete((object_id,))
         return obj

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,3 +11,4 @@ autoflake>=1.4
 pre-commit>=2.15.0
 msgpack>=1.0.5
 httpx==0.24.0
+numpy>=1.24

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -51,12 +51,6 @@ def mosec_service(request):
     "mosec_service, http_client",
     [
         pytest.param("square_service", "", id="basic"),
-        pytest.param(
-            "square_service_shm",
-            "",
-            marks=pytest.mark.arrow,
-            id="shm_arrow",
-        ),
     ],
     indirect=["mosec_service", "http_client"],
 )
@@ -78,6 +72,22 @@ def test_square_service(mosec_service, http_client):
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
     validate_square_service(http_client, 2)
+
+
+@pytest.mark.parametrize(
+    "mosec_service, http_client",
+    [
+        pytest.param(
+            "mixin_ipc_shm_service", "", id="shm_plasma", marks=pytest.mark.arrow
+        ),
+    ],
+    indirect=["mosec_service", "http_client"],
+)
+def test_mixin_ipc_shm_service(mosec_service, http_client):
+    resp = http_client.post("/inference", json={"size": 8})
+    assert resp.status_code == HTTPStatus.OK, resp
+    assert len(resp.json().get("x")) == 8
+    assert resp.headers["content-type"] == "application/json"
 
 
 @pytest.mark.parametrize(
@@ -123,12 +133,6 @@ def test_mixin_typed_service(mosec_service, http_client):
     "mosec_service, http_client",
     [
         pytest.param("square_service", "", id="basic"),
-        pytest.param(
-            "square_service_shm",
-            "",
-            marks=pytest.mark.arrow,
-            id="shm_arrow",
-        ),
     ],
     indirect=["mosec_service", "http_client"],
 )


### PR DESCRIPTION
Although plasma can handle the `np.ndarray` and common Python type serde, I think it's better to make it explicit.

This example is closer to the real scenario.
