### PR TITLE
fix: args should only be checked when server is used

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,4 +83,4 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           sudo apt update && sudo apt install redis
-          make test_arrow
+          make test_shm

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ dev:
 
 test: dev
 	echo "Running tests for the main logic"
-	pytest tests -vv -s -m "not arrow"
+	pytest tests -vv -s -m "not shm"
 	RUST_BACKTRACE=1 cargo test -vv
 
-test_arrow: dev
+test_shm: dev
 	@pip install -q -r requirements/mixin.txt
-	echo "Running tests for the mixin"
-	pytest tests -vv -s -m "arrow"
+	echo "Running tests for the shm mixin"
+	pytest tests -vv -s -m "shm"
 	pip uninstall -y -r requirements/mixin.txt
 
 test_all: dev

--- a/build.envd
+++ b/build.envd
@@ -31,9 +31,7 @@ def build():
     base(dev=True)
     install.conda()
     install.python()
-    install.python_packages(requirements="requirements/dev.txt")
     rust()
-    # run(["make install"], mount_host=True)
     runtime.init(["make install"])
 
 

--- a/mosec/args.py
+++ b/mosec/args.py
@@ -46,8 +46,8 @@ def is_port_available(addr: str, port: int) -> bool:
     )
 
 
-def parse_arguments() -> argparse.Namespace:
-    """Parse user configurations."""
+def build_arguments_parser() -> argparse.ArgumentParser:
+    """Build CLI arguments."""
     parser = argparse.ArgumentParser(
         description="Mosec Server Configurations",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -121,7 +121,12 @@ def parse_arguments() -> argparse.Namespace:
         "This will omit the worker number for each stage.",
         action="store_true",
     )
+    return parser
 
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse user configurations."""
+    parser = build_arguments_parser()
     args, _ = parser.parse_known_args(namespace=get_env_namespace())
 
     if args.wait != 10:
@@ -140,4 +145,8 @@ def parse_arguments() -> argparse.Namespace:
     return args
 
 
-mosec_args = parse_arguments()
+def is_debug_mode() -> bool:
+    """Check if the service is running in debug mode."""
+    parser = build_arguments_parser()
+    args, _ = parser.parse_known_args(namespace=get_env_namespace())
+    return args.debug

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -22,7 +22,7 @@ import os
 from datetime import datetime
 from typing import Any, MutableMapping
 
-from mosec.args import mosec_args
+from mosec.args import is_debug_mode
 
 MOSEC_LOG_NAME = __name__
 MOSEC_LOG_PREFIX = "mosec"
@@ -178,4 +178,4 @@ def set_logger(debug=False):
 
 
 # need to configure it here to make sure all the process can get the same one
-set_logger(mosec_args.debug)
+set_logger(is_debug_mode())

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -52,7 +52,7 @@ from typing import Dict, List, Optional, Type, Union
 
 import pkg_resources
 
-from mosec.args import mosec_args
+from mosec.args import parse_arguments
 from mosec.coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
 from mosec.dry_run import DryRunner
 from mosec.env import env_var_context
@@ -102,7 +102,7 @@ class Server:
 
         self._daemon: Dict[str, Union[subprocess.Popen, mp.Process]] = {}
 
-        self._configs: dict = vars(mosec_args)
+        self._configs: dict = vars(parse_arguments())
 
         self._server_shutdown: bool = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,5 +87,5 @@ convention = "google"
 
 [tool.pytest.ini_options]
 markers = [
-    "arrow: mark a test requires 'pyarrow'",
+    "shm: mark a test is related to shared memory",
 ]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -80,10 +80,10 @@ def test_square_service(mosec_service, http_client):
     "mosec_service, http_client",
     [
         pytest.param(
-            "mixin_ipc_shm_service plasma", "", id="shm_plasma", marks=pytest.mark.arrow
+            "mixin_ipc_shm_service plasma", "", id="shm_plasma", marks=pytest.mark.shm
         ),
         pytest.param(
-            "mixin_ipc_shm_service redis", "", id="shm_redis", marks=pytest.mark.arrow
+            "mixin_ipc_shm_service redis", "", id="shm_redis", marks=pytest.mark.shm
         ),
     ],
     indirect=["mosec_service", "http_client"],


### PR DESCRIPTION
Previously, if I run `pytest tests/test_utils.py` it will also check if port 8000 is free.