### PR TITLE
feat: support dynamic inference route

### DIFF
--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, List, Tuple, Union
 
 from mosec.env import env_var_context
 from mosec.log import get_internal_logger
-from mosec.manager import CoordinatorManager, WorkerRuntime
+from mosec.manager import PyRuntimeManager, Runtime
 from mosec.worker import Worker
 
 if TYPE_CHECKING:
@@ -91,7 +91,7 @@ class Pool:
         self._sender_pipes.append(sender)
         self._receiver_pipes.append(receiver)
 
-    def start_worker(self, worker_runtime: WorkerRuntime, first: bool):
+    def start_worker(self, worker_runtime: Runtime, first: bool):
         """Start the worker process for dry run.
 
         Args:
@@ -161,7 +161,7 @@ class DryRunner:
     will be used.
     """
 
-    def __init__(self, manager: CoordinatorManager):
+    def __init__(self, manager: PyRuntimeManager):
         """Init dry runner."""
         logger.info("init dry runner for %s", manager.workers)
 

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -21,10 +21,11 @@ import signal
 import sys
 import time
 from multiprocessing.context import SpawnContext, SpawnProcess
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, List, Tuple, Union
 
 from mosec.env import env_var_context
 from mosec.log import get_internal_logger
+from mosec.manager import CoordinatorManager, WorkerRuntime
 from mosec.worker import Worker
 
 if TYPE_CHECKING:
@@ -40,15 +41,15 @@ def dry_run_func(
     receiver: PipeConnection,
     sender: PipeConnection,
     ingress: bool,
-    event: Event,
+    shutdown_notify: Event,
 ):
     """Dry run simulation function."""
     worker = worker_cls()
-    while not event.is_set():
+    while not shutdown_notify.is_set():
         if receiver.poll(timeout=0.1):
             break
 
-    if event.is_set():
+    if shutdown_notify.is_set():
         return
 
     try:
@@ -64,7 +65,89 @@ def dry_run_func(
     # pylint: disable=broad-except
     except Exception as err:
         logger.error("get error in %s: %s", worker, err)
-        event.set()
+        shutdown_notify.set()
+
+
+class Pool:
+    """Process pool for dry run."""
+
+    def __init__(self, process_context: SpawnContext, shutdown_notify: Event):
+        """Initialize a process pool.
+
+        Args:
+            process_context: server context of spawn process
+            shutdown_notify: event of server will shutdown
+        """
+        self.process_context = process_context
+        self.shutdown_notify = shutdown_notify
+
+        self._pool: List[SpawnProcess] = []
+        self.sender_pipes: List[PipeConnection] = []
+        self.receiver_pipes: List[PipeConnection] = []
+
+    def new_pipe(self):
+        """Create new pipe for dry run workers to communicate."""
+        receiver, sender = self.process_context.Pipe(duplex=False)
+        self.sender_pipes.append(sender)
+        self.receiver_pipes.append(receiver)
+
+    def start_worker(self, worker_runtime: WorkerRuntime, first: bool):
+        """Start the worker process for dry run.
+
+        Args:
+            worker_runtime: worker runtime to start
+            first: whether the worker is tried to start at first time
+
+        """
+        self.new_pipe()
+        coordinator = self.process_context.Process(
+            target=dry_run_func,
+            args=(
+                worker_runtime.worker,
+                worker_runtime.max_batch_size,
+                self.receiver_pipes[-2],
+                self.sender_pipes[-1],
+                first,
+                self.shutdown_notify,
+            ),
+            daemon=True,
+        )
+
+        with env_var_context(worker_runtime.env, 0):
+            coordinator.start()
+
+        self._pool.append(coordinator)
+
+    def probe_worker_liveness(self) -> Tuple[Union[int, None], Union[int, None]]:
+        """Check every worker is running/alive.
+
+        Returns:
+            index: index of the first failed worker
+            exitcode: exitcode of the first failed worker
+
+        """
+        for i, process in enumerate(self._pool):
+            if process.exitcode is not None:
+                return i, process.exitcode
+        return None, None
+
+    def wait_all(self) -> Tuple[Union[int, None], Union[int, None]]:
+        """Blocking until all worker to end or one failed.
+
+        Returns:
+            index: index of the first failed worker
+            exitcode: exitcode of the first failed worker
+
+        """
+        for i, process in enumerate(self._pool):
+            process.join()
+            if process.exitcode != 0:
+                return i, process.exitcode
+        return None, None
+
+    def first_last_pipe(self):
+        """Get first sender and last receiver pipes."""
+        return self.sender_pipes[0], self.receiver_pipes[-1]
 
 
 class DryRunner:
@@ -78,74 +161,44 @@ class DryRunner:
     will be used.
     """
 
-    def __init__(
-        self,
-        workers: List[type[Worker]],
-        batches: List[int],
-        envs: List[None | List[Dict[str, str]]],
-    ):
+    def __init__(self, manager: CoordinatorManager):
         """Init dry runner."""
-        logger.info("init dry runner for %s", workers)
-        self.process_context = SpawnContext()
-        self.workers = workers
-        self.process_args = zip(workers, batches, envs)
-        self.pool: List[SpawnProcess] = []
-        self.sender_pipes: List[PipeConnection] = []
-        self.receiver_pipes: List[PipeConnection] = []
+        logger.info("init dry runner for %s", manager.workers)
 
-        self.event: Event = self.process_context.Event()
+        self.manager = manager
+        self.process_context: SpawnContext = SpawnContext()
+        self.shutdown_notify: Event = self.process_context.Event()
+        self.pool = Pool(self.process_context, self.shutdown_notify)
+
         signal.signal(signal.SIGTERM, self.terminate)
         signal.signal(signal.SIGINT, self.terminate)
 
     def terminate(self, signum, framestack):
         """Terminate the dry run."""
         logger.info("received terminate signal [%s] %s", signum, framestack)
-        self.event.set()
-
-    def new_pipe(self):
-        """Create new pipe for dry run workers to communicate."""
-        receiver, sender = self.process_context.Pipe(duplex=False)
-        self.sender_pipes.append(sender)
-        self.receiver_pipes.append(receiver)
+        self.shutdown_notify.set()
 
     def run(self):
         """Execute thr dry run process."""
-        self.new_pipe()
-        for i, (worker, batch, env) in enumerate(self.process_args):
-            self.new_pipe()
-            coordinator = self.process_context.Process(
-                target=dry_run_func,
-                args=(
-                    worker,
-                    batch,
-                    self.receiver_pipes[-2],
-                    self.sender_pipes[-1],
-                    i == 0,
-                    self.event,
-                ),
-                daemon=True,
-            )
-
-            with env_var_context(env, 0):
-                coordinator.start()
-
-            self.pool.append(coordinator)
+        self.pool.new_pipe()
+        for i, worker_runtime in enumerate(self.manager):
+            self.pool.start_worker(worker_runtime, i == 0)
 
         logger.info("dry run init successful")
         self.warmup()
 
         logger.info("wait for worker init done")
-        if not self.event.is_set():
-            self.event.set()
-        for i, process in enumerate(self.pool):
-            process.join()
-            if process.exitcode != 0:
-                logger.warning(
-                    "detect abnormal exit code %d in %s",
-                    process.exitcode,
-                    self.workers[i],
-                )
-                sys.exit(process.exitcode)
+        if not self.shutdown_notify.is_set():
+            self.shutdown_notify.set()
+
+        failed, exitcode = self.pool.wait_all()
+        if failed is not None:
+            logger.warning(
+                "detect %s with abnormal exit code %d",
+                self.manager.workers[failed],
+                exitcode,
+            )
+            sys.exit(exitcode)
         logger.info("dry run exit")
 
     def warmup(self):
@@ -154,7 +207,7 @@ class DryRunner:
         If neither `example` nor `multi_examples` is provided, it will only
         init the worker class.
         """
-        ingress = self.workers[0]
+        ingress = self.manager.workers[0]
         example = None
         if ingress.example:
             example = ingress.example
@@ -168,24 +221,25 @@ class DryRunner:
             logger.info("cannot find the example in the 1st stage worker, skip warmup")
             return
 
-        sender, receiver = self.sender_pipes[0], self.receiver_pipes[-1]
+        sender, receiver = self.pool.first_last_pipe()
         start_time = time.perf_counter()
         sender.send(example)
 
-        while not self.event.is_set():
+        while not self.shutdown_notify.is_set():
             if receiver.poll(0.1):
                 break
-
             # liveness probe
-            for i, process in enumerate(self.pool):
-                if process.exitcode is not None:
-                    logger.warning(
-                        "worker %s exit with code %d", self.workers[i], process.exitcode
-                    )
-                    self.event.set()
-                    break
+            failed, exitcode = self.pool.probe_worker_liveness()
+            if failed is not None:
+                logger.warning(
+                    "worker %s exit with code %d",
+                    self.manager.workers[failed],
+                    exitcode,
+                )
+                self.shutdown_notify.set()
+                break
 
-        if self.event.is_set():
+        if self.shutdown_notify.is_set():
             sys.exit(1)
 
         res = receiver.recv_bytes()

--- a/mosec/env.py
+++ b/mosec/env.py
@@ -20,7 +20,7 @@ import contextlib
 import os
 import warnings
 from argparse import Namespace
-from typing import Dict, List
+from typing import Any, Dict, List, Union
 
 MOSEC_ENV_PREFIX = "MOSEC_"
 MOSEC_ENV_CONFIG = {
@@ -72,3 +72,32 @@ def get_env_namespace(prefix: str = MOSEC_ENV_PREFIX) -> Namespace:
             setattr(namespace, name, val)
 
     return namespace
+
+
+def validate_int_ge(number, name, threshold=1):
+    """Validate int number is greater than threshold."""
+    assert isinstance(
+        number, int
+    ), f"{name} must be integer but you give {type(number)}"
+    assert number >= threshold, f"{name} must be no less than {threshold}"
+
+
+def validate_str_dict(dictionary: Dict):
+    """Validate keys and values of the dictionary is string type."""
+    for key, value in dictionary.items():
+        if not (isinstance(key, str) and isinstance(value, str)):
+            return False
+    return True
+
+
+def validate_env(env: Union[Any, List[Dict[str, str]]], num: int):
+    """Validate keys and values of the dictionary is string type."""
+    if env is None:
+        return
+    assert len(env) == num, "len(env) must equal to num"
+    valid = True
+    if not isinstance(env, List):
+        valid = False
+    elif not all(isinstance(x, Dict) and validate_str_dict(x) for x in env):
+        valid = False
+    assert valid, "env must be a list of string dictionary"

--- a/mosec/manager.py
+++ b/mosec/manager.py
@@ -243,7 +243,7 @@ class PyRuntimeManager:
         return None
 
 
-class RsRuntimeManage:
+class RsRuntimeManager:
     """The manager to control Mosec process."""
 
     def __init__(

--- a/mosec/manager.py
+++ b/mosec/manager.py
@@ -1,0 +1,310 @@
+# Copyright 2023 MOSEC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Managers to control Coordinator and Mosec process."""
+
+import multiprocessing as mp
+import subprocess
+from functools import partial
+from multiprocessing.context import ForkContext, SpawnContext
+from multiprocessing.process import BaseProcess
+from multiprocessing.synchronize import Event
+from pathlib import Path
+from time import monotonic, sleep
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type, Union, cast
+
+import pkg_resources
+
+from mosec.coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
+from mosec.env import env_var_context, validate_env, validate_int_ge
+from mosec.ipc import IPCWrapper
+from mosec.log import get_internal_logger
+from mosec.worker import Worker
+
+logger = get_internal_logger()
+
+NEW_PROCESS_METHOD = {"spawn", "fork"}
+
+
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-arguments
+class WorkerRuntime:
+    """The wrapper with one worker and its arguments."""
+
+    def __init__(
+        self,
+        worker: Type[Worker],
+        num: int,
+        max_batch_size: int,
+        max_wait_time: int,
+        stage_id: int,
+        timeout: int,
+        start_method: str,
+        env: Union[None, List[Dict[str, str]]],
+        ipc_wrapper: Optional[Union[Type[IPCWrapper], partial]],
+    ):
+        """Initialize the mosec coordinator.
+
+        Args:
+            worker (Worker): subclass of `mosec.Worker` implemented by users.
+            num (int): number of workers
+            max_batch_size: the maximum batch size allowed (>=1), will enable the
+                dynamic batching if it > 1
+            max_wait_time (int): the maximum wait time (millisecond)
+                for dynamic batching, needs to be used with `max_batch_size`
+                to enable the feature. If not configure, will use the CLI
+                argument `--wait` (default=10ms)
+            stage_id (int): identification number for worker stages.
+            timeout (int): timeout for the `forward` function.
+            start_method: the process starting method ("spawn" or "fork")
+            env: the environment variables to set before starting the process
+            ipc_wrapper (IPCWrapper): IPC wrapper class to be initialized.
+
+
+        Raises:
+            TypeError: ipc_wrapper should inherit from `IPCWrapper`
+        """
+        self.worker = worker
+        self.num = num
+        self.max_batch_size = max_batch_size
+        self.max_wait_time = max_wait_time
+        self.stage_id = stage_id
+        self.timeout = timeout
+        self.start_method = start_method
+        self.env = env
+        self.ipc_wrapper = ipc_wrapper
+
+        self.pool: List[Union[BaseProcess, None]] = [None for _ in range(self.num)]
+
+    @staticmethod
+    def _process_healthy(process: Union[BaseProcess, None]):
+        return process is not None and process.exitcode is not None
+
+    def _healthy(self, method: Callable[[Iterable[object]], bool]):
+        return method(self.pool)
+
+    def _start_process(
+        self,
+        worker_id: int,
+        stage_label: str,
+        work_path: str,
+        shutdown: Event,
+        shutdown_notify: Event,
+    ):
+        context = mp.get_context(self.start_method)
+        context = cast(Union[SpawnContext, ForkContext], context)
+        coordinator_process = context.Process(
+            target=Coordinator,
+            args=(
+                self.worker,
+                self.max_batch_size,
+                stage_label,
+                shutdown,
+                shutdown_notify,
+                work_path,
+                self.stage_id,
+                worker_id + 1,
+                self.ipc_wrapper,
+                self.timeout,
+            ),
+            daemon=True,
+        )
+
+        with env_var_context(self.env, worker_id):
+            coordinator_process.start()
+
+        self.pool[worker_id] = coordinator_process
+
+    def start(
+        self,
+        first: bool,
+        stage_label: str,
+        work_path: str,
+        shutdown: Event,
+        shutdown_notify: Event,
+    ):
+        """Start the worker process.
+
+        Args:
+            first: whether the worker is tried to start at first time
+            stage_label: label of worker ingress and egress
+            work_path: path of working directory
+            shutdown: Event of server shutdown
+            shutdown_notify: Event of server will shutdown
+
+        Returns:
+            Whether the worker is started successfully
+        """
+        # for every sequential stage
+        self.pool = [p if self._process_healthy(p) else None for p in self.pool]
+        if self._healthy(all):
+            # this stage is healthy
+            return True
+        if not first and not self._healthy(any):
+            # this stage might contain bugs
+            return False
+
+        need_start_id = [
+            worker_id for worker_id in range(self.num) if self.pool[worker_id] is None
+        ]
+        for worker_id in need_start_id:
+            # for every worker in each stage
+            self._start_process(
+                worker_id, stage_label, work_path, shutdown, shutdown_notify
+            )
+        return True
+
+    def validate(self):
+        """Validate arguments of worker runtime."""
+        validate_env(self.env, self.num)
+        assert issubclass(
+            self.worker, Worker
+        ), "worker must be inherited from mosec.Worker"
+        validate_int_ge(self.num, "worker number")
+        validate_int_ge(self.max_batch_size, "maximum batch size")
+        validate_int_ge(self.max_wait_time, "maximum wait time", 0)
+        validate_int_ge(self.timeout, "forward timeout", 0)
+        assert (
+            self.start_method in NEW_PROCESS_METHOD
+        ), f"start method must be one of {NEW_PROCESS_METHOD}"
+
+
+class CoordinatorManager:
+    """The manager to control coordinator process."""
+
+    def __init__(self, work_path: str, shutdown: Event, shutdown_notify: Event):
+        """Initialize a coordinator manager.
+
+        Args:
+            work_path: path of working directory
+            shutdown: Event of server shutdown
+            shutdown_notify: Event of server will shutdown
+        """
+        self._worker_runtimes: List[WorkerRuntime] = []
+
+        self._work_path = work_path
+        self._shutdown = shutdown
+        self._shutdown_notify = shutdown_notify
+
+    def __iter__(self):
+        """Iterate workers of manager."""
+        return self._worker_runtimes.__iter__()
+
+    @property
+    def worker_count(self):
+        """Get number of workers."""
+        return len(self._worker_runtimes)
+
+    @property
+    def workers(self):
+        """Get List of workers."""
+        return [r.worker for r in self._worker_runtimes]
+
+    def egress_mime(self):
+        """Return mime of egress worker."""
+        return self._worker_runtimes[-1].worker.resp_mime_type
+
+    def append(self, runtime: WorkerRuntime):
+        """Sequentially appends workers to the workflow pipeline."""
+        self._worker_runtimes.append(runtime)
+
+    def _label_stage(self, stage_id: int):
+        stage = ""
+        if stage_id == 0:
+            stage += STAGE_INGRESS
+        if stage_id == self.worker_count - 1:
+            stage += STAGE_EGRESS
+        return stage
+
+    def check_and_start(self, first: bool) -> Union[WorkerRuntime, None]:
+        """Check all worker processes and try to start failed ones.
+
+        Args:
+            first: whether the worker is tried to start at first time
+        """
+        for stage_id, worker_runtime in enumerate(self._worker_runtimes):
+            label = self._label_stage(stage_id)
+            success = worker_runtime.start(
+                first, label, self._work_path, self._shutdown, self._shutdown_notify
+            )
+            if not success:
+                return worker_runtime
+        return None
+
+
+class Controller:
+    """The manager to control Mosec process."""
+
+    def __init__(
+        self, manager: CoordinatorManager, endpoint: str, configs: Dict[str, Any]
+    ):
+        """Initialize a Mosec manager.
+
+        Args:
+            manager: manager of coordinator
+            endpoint: event of server shutdown
+            configs: config
+        """
+        self._process: Optional[subprocess.Popen] = None
+
+        self._coordinator_manager: CoordinatorManager = manager
+        self._endpoint = endpoint
+        self._server_path = Path(
+            pkg_resources.resource_filename("mosec", "bin"), "mosec"
+        )
+        self._configs: Dict[str, Any] = configs
+
+    def halt(self):
+        """Graceful shutdown."""
+        # terminate controller first and wait for a graceful period
+        if self._process is None:
+            return
+        self._process.terminate()
+        graceful_period = monotonic() + self._configs["timeout"] / 1000
+        while monotonic() < graceful_period:
+            ctr_exitcode = self._process.poll()
+            if ctr_exitcode is None:
+                sleep(0.1)
+                continue
+            # exited
+            if ctr_exitcode:  # on error
+                logger.error("mosec service halted on error [%d]", ctr_exitcode)
+            else:
+                logger.info("mosec service halted normally [%d]", ctr_exitcode)
+            break
+
+        if monotonic() > graceful_period:
+            logger.error("failed to terminate mosec service, will try to kill it")
+            self._process.kill()
+
+    def start(self):
+        """Start the Mosec process."""
+        # pylint: disable=consider-using-with
+        self._process = subprocess.Popen([self._server_path] + self._controller_args())
+        return self._process
+
+    def _controller_args(self):
+        args = []
+        self._configs.pop("dry_run")
+        self._configs["debug"] = True
+        for key, value in self._configs.items():
+            args.extend([f"--{key}", str(value).lower()])
+        for worker_runtime in self._coordinator_manager:
+            args.extend(["--batches", str(worker_runtime.max_batch_size)])
+            args.extend(["--waits", str(worker_runtime.max_wait_time)])
+        mime_type = self._coordinator_manager.egress_mime()
+        args.extend(["--mime", mime_type])
+        args.extend(["--endpoint", self._endpoint])
+        logger.info("mosec received arguments: %s", args)
+        return args

--- a/mosec/manager.py
+++ b/mosec/manager.py
@@ -88,10 +88,10 @@ class WorkerRuntime:
         self.pool: List[Union[BaseProcess, None]] = [None for _ in range(self.num)]
 
     @staticmethod
-    def _process_healthy(process: Union[BaseProcess, None]):
+    def _process_healthy(process: Union[BaseProcess, None]) -> bool:
         return process is not None and process.exitcode is not None
 
-    def _healthy(self, method: Callable[[Iterable[object]], bool]):
+    def _healthy(self, method: Callable[[Iterable[object]], bool]) -> bool:
         return method(self.pool)
 
     def _start_process(
@@ -133,7 +133,7 @@ class WorkerRuntime:
         work_path: str,
         shutdown: Event,
         shutdown_notify: Event,
-    ):
+    ) -> bool:
         """Start the worker process.
 
         Args:
@@ -202,16 +202,16 @@ class CoordinatorManager:
         return self._worker_runtimes.__iter__()
 
     @property
-    def worker_count(self):
+    def worker_count(self) -> int:
         """Get number of workers."""
         return len(self._worker_runtimes)
 
     @property
-    def workers(self):
+    def workers(self) -> List[Type[Worker]]:
         """Get List of workers."""
         return [r.worker for r in self._worker_runtimes]
 
-    def egress_mime(self):
+    def egress_mime(self) -> str:
         """Return mime of egress worker."""
         return self._worker_runtimes[-1].worker.resp_mime_type
 
@@ -219,7 +219,7 @@ class CoordinatorManager:
         """Sequentially appends workers to the workflow pipeline."""
         self._worker_runtimes.append(runtime)
 
-    def _label_stage(self, stage_id: int):
+    def _label_stage(self, stage_id: int) -> str:
         stage = ""
         if stage_id == 0:
             stage += STAGE_INGRESS
@@ -288,7 +288,7 @@ class Controller:
             logger.error("failed to terminate mosec service, will try to kill it")
             self._process.kill()
 
-    def start(self):
+    def start(self) -> subprocess.Popen:
         """Start the Mosec process."""
         # pylint: disable=consider-using-with
         self._process = subprocess.Popen([self._server_path] + self._controller_args())
@@ -297,7 +297,6 @@ class Controller:
     def _controller_args(self):
         args = []
         self._configs.pop("dry_run")
-        self._configs["debug"] = True
         for key, value in self._configs.items():
             args.extend([f"--{key}", str(value).lower()])
         for worker_runtime in self._coordinator_manager:

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -46,25 +46,20 @@ import subprocess
 import traceback
 from functools import partial
 from multiprocessing.synchronize import Event
-from pathlib import Path
-from time import monotonic, sleep
+from time import sleep
 from typing import Dict, List, Optional, Type, Union
 
-import pkg_resources
-
 from mosec.args import parse_arguments
-from mosec.coordinator import STAGE_EGRESS, STAGE_INGRESS, Coordinator
 from mosec.dry_run import DryRunner
-from mosec.env import env_var_context
 from mosec.ipc import IPCWrapper
 from mosec.log import get_internal_logger
+from mosec.manager import Controller, CoordinatorManager, WorkerRuntime
 from mosec.worker import Worker
 
 logger = get_internal_logger()
 
 
 GUARD_CHECK_INTERVAL = 1
-NEW_PROCESS_METHOD = {"spawn", "fork"}
 
 
 class Server:
@@ -78,31 +73,27 @@ class Server:
     def __init__(
         self,
         ipc_wrapper: Optional[Union[IPCWrapper, partial]] = None,
+        endpoint: str = "/inference",
     ):
         """Initialize a MOSEC Server.
 
         Args:
             ipc_wrapper: wrapper function (before and after) IPC
+            endpoint: path to route inference
         """
         self.ipc_wrapper = ipc_wrapper
+        self.endpoint = endpoint
 
-        self._worker_cls: List[Type[Worker]] = []
-        self._worker_num: List[int] = []
-        self._worker_mbs: List[int] = []
-        self._worker_wait: List[int] = []
-        self._worker_timeout: List[int] = []
+        self._shutdown: Event = mp.get_context("spawn").Event()
+        self._shutdown_notify: Event = mp.get_context("spawn").Event()
+        self._configs: dict = vars(parse_arguments())
 
-        self._coordinator_env: List[Union[None, List[Dict[str, str]]]] = []
-        self._coordinator_ctx: List[str] = []
-        self._coordinator_pools: List[List[Union[mp.Process, None]]] = []
-        self._coordinator_shutdown: Event = mp.get_context("spawn").Event()
-        self._coordinator_shutdown_notify: Event = mp.get_context("spawn").Event()
-
-        self._controller_process: Optional[subprocess.Popen] = None
+        self.coordinator_manager: CoordinatorManager = CoordinatorManager(
+            self._configs["path"], self._shutdown, self._shutdown_notify
+        )
+        self.controller = Controller(self.coordinator_manager, endpoint, self._configs)
 
         self._daemon: Dict[str, Union[subprocess.Popen, mp.Process]] = {}
-
-        self._configs: dict = vars(parse_arguments())
 
         self._server_shutdown: bool = False
 
@@ -111,54 +102,10 @@ class Server:
         signal.signal(signal.SIGINT, self._terminate)
 
     def _validate_server(self):
-        assert len(self._worker_cls) > 0, (
+        assert self.coordinator_manager.worker_count > 0, (
             "no worker registered\n"
             "help: use `.append_worker(...)` to register at least one worker"
         )
-
-    @staticmethod
-    def _validate_arguments(
-        worker,
-        num,
-        max_batch_size,
-        max_wait_time,
-        start_method,
-        env,
-        timeout,
-    ):
-        def validate_int_ge(number, name, threshold=1):
-            assert isinstance(
-                number, int
-            ), f"{name} must be integer but you give {type(number)}"
-            assert number >= threshold, f"{name} must be no less than {threshold}"
-
-        def validate_env():
-            if env is None:
-                return
-
-            def validate_str_dict(dictionary: Dict):
-                for key, value in dictionary.items():
-                    if not (isinstance(key, str) and isinstance(value, str)):
-                        return False
-                return True
-
-            assert len(env) == num, "len(env) must equal to num"
-            valid = True
-            if not isinstance(env, List):
-                valid = False
-            elif not all(isinstance(x, Dict) and validate_str_dict(x) for x in env):
-                valid = False
-            assert valid, "env must be a list of string dictionary"
-
-        validate_env()
-        assert issubclass(worker, Worker), "worker must be inherited from mosec.Worker"
-        validate_int_ge(num, "worker number")
-        validate_int_ge(max_batch_size, "maximum batch size")
-        validate_int_ge(max_wait_time, "maximum wait time", 0)
-        validate_int_ge(timeout, "forward timeout", 0)
-        assert (
-            start_method in NEW_PROCESS_METHOD
-        ), f"start method must be one of {NEW_PROCESS_METHOD}"
 
     def _check_daemon(self):
         for name, proc in self._daemon.items():
@@ -176,108 +123,28 @@ class Server:
                     f"mosec daemon [{name}] exited on error code: {code}",
                 )
 
-    def _controller_args(self):
-        args = []
-        self._configs.pop("dry_run")
-        for key, value in self._configs.items():
-            args.extend([f"--{key}", str(value).lower()])
-        for batch_size in self._worker_mbs:
-            args.extend(["--batches", str(batch_size)])
-        for wait_time in self._worker_wait:
-            args.extend(
-                ["--waits", str(wait_time if wait_time else self._configs["wait"])]
-            )
-        mime_type = self._worker_cls[-1].resp_mime_type
-        args.extend(["--mime", mime_type])
-        logger.info("mosec received arguments: %s", args)
-        return args
-
     def _start_controller(self):
         """Subprocess to start controller program."""
-        if not self._server_shutdown:
-            path = Path(pkg_resources.resource_filename("mosec", "bin"), "mosec")
-            # pylint: disable=consider-using-with
-            self._controller_process = subprocess.Popen(
-                [path] + self._controller_args()
-            )
-            self.register_daemon("controller", self._controller_process)
+        if self._server_shutdown:
+            return
+        process = self.controller.start()
+        self.register_daemon("controller", process)
 
     def _terminate(self, signum, framestack):
         logger.info("received signum[%s], terminating server [%s]", signum, framestack)
         self._server_shutdown = True
 
-    @staticmethod
-    def _clean_pools(
-        processes: List[Union[mp.Process, None]],
-    ) -> List[Union[mp.Process, None]]:
-        for i, process in enumerate(processes):
-            if process is None or process.exitcode is not None:
-                processes[i] = None
-        return processes
-
     def _manage_coordinators(self):
         first = True
         while not self._server_shutdown:
-            for stage_id, (w_cls, w_num, w_mbs, w_timeout, c_ctx, c_env) in enumerate(
-                zip(
-                    self._worker_cls,
-                    self._worker_num,
-                    self._worker_mbs,
-                    self._worker_timeout,
-                    self._coordinator_ctx,
-                    self._coordinator_env,
+            failed_worker = self.coordinator_manager.check_and_start(first)
+            if failed_worker is not None:
+                self._terminate(
+                    1,
+                    f"all the {failed_worker.worker.__name__} workers"
+                    f" at stage {failed_worker.stage_id} exited;"
+                    " please check for bugs or socket connection issues",
                 )
-            ):
-                # for every sequential stage
-                self._coordinator_pools[stage_id] = self._clean_pools(
-                    self._coordinator_pools[stage_id]
-                )
-
-                if all(self._coordinator_pools[stage_id]):
-                    # this stage is healthy
-                    continue
-
-                if not first and not any(self._coordinator_pools[stage_id]):
-                    # this stage might contain bugs
-                    self._terminate(
-                        1,
-                        f"all the {w_cls.__name__} workers at stage {stage_id} exited;"
-                        " please check for bugs or socket connection issues",
-                    )
-                    break
-
-                stage = ""
-                if stage_id == 0:
-                    stage += STAGE_INGRESS
-                if stage_id == len(self._worker_cls) - 1:
-                    stage += STAGE_EGRESS
-
-                for worker_id in range(w_num):
-                    # for every worker in each stage
-                    if self._coordinator_pools[stage_id][worker_id] is not None:
-                        continue
-
-                    coordinator_process = mp.get_context(c_ctx).Process(  # type: ignore
-                        target=Coordinator,
-                        args=(
-                            w_cls,
-                            w_mbs,
-                            stage,
-                            self._coordinator_shutdown,
-                            self._coordinator_shutdown_notify,
-                            self._configs["path"],
-                            stage_id + 1,
-                            worker_id + 1,
-                            self.ipc_wrapper,
-                            w_timeout,
-                        ),
-                        daemon=True,
-                    )
-
-                    with env_var_context(c_env, worker_id):
-                        coordinator_process.start()
-
-                    self._coordinator_pools[stage_id][worker_id] = coordinator_process
             first = False
             self._check_daemon()
             sleep(GUARD_CHECK_INTERVAL)
@@ -285,28 +152,10 @@ class Server:
     def _halt(self):
         """Graceful shutdown."""
         # notify coordinators for the shutdown
-        self._coordinator_shutdown_notify.set()
-
-        # terminate controller first and wait for a graceful period
-        if self._controller_process is not None:
-            self._controller_process.terminate()
-            graceful_period = monotonic() + self._configs["timeout"] / 1000
-            while monotonic() < graceful_period:
-                ctr_exitcode = self._controller_process.poll()
-                if ctr_exitcode is not None:  # exited
-                    if ctr_exitcode:  # on error
-                        logger.error("mosec service halted on error [%d]", ctr_exitcode)
-                    else:
-                        logger.info("mosec service halted normally [%d]", ctr_exitcode)
-                    break
-                sleep(0.1)
-
-            if monotonic() > graceful_period:
-                logger.error("failed to terminate mosec service, will try to kill it")
-                self._controller_process.kill()
-
+        self._shutdown_notify.set()
+        self.controller.halt()
         # shutdown coordinators
-        self._coordinator_shutdown.set()
+        self._shutdown.set()
         shutil.rmtree(self._configs["path"], ignore_errors=True)
         logger.info("mosec exited normally")
 
@@ -349,29 +198,28 @@ class Server:
             env: the environment variables to set before starting the process
             timeout: the timeout (second) for each worker forward processing (>=1)
         """
-        self._validate_arguments(
-            worker, num, max_batch_size, max_wait_time, start_method, env, timeout
+        timeout = timeout if timeout >= 1 else self._configs["timeout"] // 1000
+        max_wait_time = max_wait_time if max_wait_time >= 1 else self._configs["wait"]
+        stage_id = self.coordinator_manager.worker_count
+        runtime = WorkerRuntime(
+            worker,
+            num,
+            max_batch_size,
+            max_wait_time,
+            stage_id + 1,
+            timeout,
+            start_method,
+            env,
+            None,
         )
-        self._worker_cls.append(worker)
-        self._worker_num.append(num)
-        self._worker_mbs.append(max_batch_size)
-        self._worker_wait.append(max_wait_time)
-        self._worker_timeout.append(
-            timeout if timeout >= 1 else self._configs["timeout"] // 1000
-        )
-        self._coordinator_env.append(env)
-        self._coordinator_ctx.append(start_method)
-        self._coordinator_pools.append([None] * num)
+        runtime.validate()
+        self.coordinator_manager.append(runtime)
 
     def run(self):
         """Start the mosec model server."""
         self._validate_server()
         if self._configs["dry_run"]:
-            DryRunner(
-                self._worker_cls,
-                self._worker_mbs,
-                self._coordinator_env,
-            ).run()
+            DryRunner(self.coordinator_manager).run()
             return
 
         self._handle_signal()

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -53,7 +53,7 @@ from mosec.args import parse_arguments
 from mosec.dry_run import DryRunner
 from mosec.ipc import IPCWrapper
 from mosec.log import get_internal_logger
-from mosec.manager import PyRuntimeManager, RsRuntimeManage, Runtime
+from mosec.manager import PyRuntimeManager, RsRuntimeManager, Runtime
 from mosec.worker import Worker
 
 logger = get_internal_logger()
@@ -91,7 +91,7 @@ class Server:
         self.coordinator_manager: PyRuntimeManager = PyRuntimeManager(
             self._configs["path"], self._shutdown, self._shutdown_notify
         )
-        self.controller = RsRuntimeManage(
+        self.controller = RsRuntimeManager(
             self.coordinator_manager, endpoint, self._configs
         )
 

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -53,7 +53,7 @@ from mosec.args import parse_arguments
 from mosec.dry_run import DryRunner
 from mosec.ipc import IPCWrapper
 from mosec.log import get_internal_logger
-from mosec.manager import Controller, CoordinatorManager, WorkerRuntime
+from mosec.manager import PyRuntimeManager, RsRuntimeManage, Runtime
 from mosec.worker import Worker
 
 logger = get_internal_logger()
@@ -88,10 +88,12 @@ class Server:
         self._shutdown_notify: Event = mp.get_context("spawn").Event()
         self._configs: dict = vars(parse_arguments())
 
-        self.coordinator_manager: CoordinatorManager = CoordinatorManager(
+        self.coordinator_manager: PyRuntimeManager = PyRuntimeManager(
             self._configs["path"], self._shutdown, self._shutdown_notify
         )
-        self.controller = Controller(self.coordinator_manager, endpoint, self._configs)
+        self.controller = RsRuntimeManage(
+            self.coordinator_manager, endpoint, self._configs
+        )
 
         self._daemon: Dict[str, Union[subprocess.Popen, mp.Process]] = {}
 
@@ -201,7 +203,7 @@ class Server:
         timeout = timeout if timeout >= 1 else self._configs["timeout"] // 1000
         max_wait_time = max_wait_time if max_wait_time >= 1 else self._configs["wait"]
         stage_id = self.coordinator_manager.worker_count
-        runtime = WorkerRuntime(
+        runtime = Runtime(
             worker,
             num,
             max_batch_size,

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,6 +17,10 @@ use argh::FromArgs;
 #[derive(FromArgs, Debug, PartialEq)]
 /// MOSEC arguments
 pub(crate) struct Opts {
+    /// the Endpoint of inference
+    #[argh(option, default = "String::from(\"/inference\")")]
+    pub(crate) endpoint: String,
+
     /// the Unix domain socket directory path
     #[argh(option, default = "String::from(\"\")")]
     pub(crate) path: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,11 +177,10 @@ async fn run(opts: &Opts) {
     let coordinator = Coordinator::init_from_opts(opts);
     let barrier = coordinator.run();
     barrier.wait().await;
-
     let app = Router::new()
         .route("/", get(index))
         .route("/metrics", get(metrics))
-        .route("/inference", post(inference))
+        .route(&opts.endpoint, post(inference))
         .with_state(state);
 
     let addr: SocketAddr = format!("{}:{}", opts.address, opts.port).parse().unwrap();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -57,6 +57,7 @@ pub(crate) async fn communicate(
         let receiver_clone = receiver.clone();
         let stage_id_label = stage_id.clone();
         let connection_id_label = connection_id.to_string();
+        info!(?path, "begin listening to socket");
         match listener.accept().await {
             Ok((mut stream, addr)) => {
                 info!(?addr, "socket accepted connection from");

--- a/tests/square_service.py
+++ b/tests/square_service.py
@@ -28,6 +28,6 @@ class SquareService(Worker):
 
 
 if __name__ == "__main__":
-    server = Server()
+    server = Server(endpoint="/v1/inference")
     server.append_worker(SquareService, max_batch_size=8)
     server.run()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -31,7 +31,7 @@ import msgpack  # type: ignore
 import pytest
 
 from mosec.coordinator import PROTOCOL_TIMEOUT, STAGE_EGRESS, STAGE_INGRESS, Coordinator
-from mosec.manager import WorkerRuntime
+from mosec.manager import Runtime
 from mosec.mixin import MsgpackMixin
 from mosec.protocol import HTTPStautsCode, _recv_all
 from mosec.worker import Worker

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -66,11 +66,11 @@ def test_square_service(mosec_service, http_client):
     resp = http_client.get("/metrics")
     assert resp.status_code == HTTPStatus.OK
 
-    resp = http_client.post("/inference", json={"msg": 2})
+    resp = http_client.post("/v1/inference", json={"msg": 2})
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp.text == "request validation error: 'x'"
 
-    resp = http_client.post("/inference", content=b"bad-binary-request")
+    resp = http_client.post("/v1/inference", content=b"bad-binary-request")
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
     validate_square_service(http_client, 2)
@@ -157,7 +157,7 @@ def test_square_service_mp(mosec_service, http_client):
 
 
 def validate_square_service(http_client, x):
-    resp = http_client.post("/inference", json={"x": x})
+    resp = http_client.post("/v1/inference", json={"x": x})
     assert resp.status_code == HTTPStatus.OK
     assert resp.json()["x"] == x**2
 


### PR DESCRIPTION
- Refactor of `Server` and `dry_run`
- Support dynamic route by adding `endpoint` argument to `Server`

Refactor:
```mermaid
graph LR
1[Server] --> 2[Controller]
1[Server] --> 3[CoordinatorManager]
2[Controller] -->|start\nhalt\ngenerate args| 4[Rust process]
3[CoordinatorManager] --> 5>WorkerRuntime 1]
3[CoordinatorManager] --> 6>WorkerRuntime 2]
3[CoordinatorManager] --> 7>WorkerRuntime 3]
5>WorkerRuntime 1] -->|start\nvalidate args\nhealth check| 8[Coordinator process * num]
6>WorkerRuntime 2] -->|start\nvalidate args\nhealth check| 9[Coordinator process * num]
7>WorkerRuntime 3] -->|start\nvalidate args\nhealth check| 10[Coordinator process * num]
```


API:
```python
server = Server(endpoint="/v1/inference")
server.append_worker(Service)
server.run()
```