### PR TITLE
chore: align the naming, fix the test lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,9 @@ lint:
 	@pip install -q -e .
 	isort --check --diff --project=mosec ${PY_SOURCE_FILES}
 	black --check --diff ${PY_SOURCE_FILES}
-	pylint -j 8 --recursive=y mosec
+	pylint -j 8 --recursive=y mosec setup.py
 	pylint -j 8 --recursive=y --disable=import-error examples --generated-members=numpy.*,torch.*,cv2.*,cv.*
+	pylint -j 8 --recursive=y tests --disable=unused-argument,missing-function-docstring,missing-class-docstring,redefined-outer-name,too-few-public-methods,consider-using-with
 	pydocstyle mosec
 	@-rm mosec/_version.py
 	pyright --stats

--- a/examples/jax_single_layer_cli.py
+++ b/examples/jax_single_layer_cli.py
@@ -14,6 +14,7 @@
 """Example: Client of the Jax server."""
 
 import random
+from http import HTTPStatus
 
 import httpx
 
@@ -24,7 +25,7 @@ prediction = httpx.post(
     "http://127.0.0.1:8000/inference",
     json={"array": input_data},
 )
-if prediction.status_code == 200:
+if prediction.status_code == HTTPStatus.OK:
     print(prediction.json())
 else:
     print(prediction.status_code, prediction.json())

--- a/examples/resnet50_client_msgpack.py
+++ b/examples/resnet50_client_msgpack.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Example: Sample Resnet client."""
 
+from http import HTTPStatus
+
 import httpx
 import msgpack  # type: ignore
 
@@ -25,7 +27,7 @@ prediction = httpx.post(
     "http://127.0.0.1:8000/inference",
     content=msgpack.packb({"image": dog_bytes}),
 )
-if prediction.status_code == 200:
+if prediction.status_code == HTTPStatus.OK:
     print(msgpack.unpackb(prediction.content))
 else:
     print(prediction.status_code, prediction.content)

--- a/examples/stable_diffusion/client.py
+++ b/examples/stable_diffusion/client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+from http import HTTPStatus
 
 import httpx
 import msgpack  # type: ignore
@@ -40,7 +41,7 @@ resp = httpx.post(
     content=msgpack.packb(args.prompt),
     timeout=httpx.Timeout(20),
 )
-if resp.status_code == 200:
+if resp.status_code == HTTPStatus.OK:
     data = msgpack.unpackb(resp.content)
     with open(args.output, "wb") as f:
         f.write(data)

--- a/mosec/args.py
+++ b/mosec/args.py
@@ -31,6 +31,8 @@ import warnings
 
 from mosec.env import get_env_namespace
 
+DEFAULT_WAIT_MS = 10
+
 
 def is_port_available(addr: str, port: int) -> bool:
     """Check if the port is available to use."""
@@ -38,9 +40,9 @@ def is_port_available(addr: str, port: int) -> bool:
     err = sock.connect_ex((addr, port))
     sock.close()
     # https://docs.python.org/3/library/errno.html
-    if 0 == err:
+    if err == 0:
         return False
-    if errno.ECONNREFUSED == err:
+    if err == errno.ECONNREFUSED:
         return True
     raise RuntimeError(
         f"Check {addr}:{port} socket connection err: {err}{errno.errorcode[err]}"
@@ -86,7 +88,7 @@ def build_arguments_parser() -> argparse.ArgumentParser:
         "--wait",
         help="[deprecated] Wait time for the batcher to batch (milliseconds)",
         type=int,
-        default=10,
+        default=DEFAULT_WAIT_MS,
     )
 
     parser.add_argument(
@@ -137,7 +139,7 @@ def parse_arguments() -> argparse.Namespace:
     parser = build_arguments_parser()
     args, _ = parser.parse_known_args(namespace=get_env_namespace())
 
-    if args.wait != 10:
+    if args.wait != DEFAULT_WAIT_MS:
         warnings.warn(
             "`--wait` is deprecated and will be removed in v1, please configure"
             "the `max_wait_time` on `Server.append_worker`",

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -55,10 +55,7 @@ def dry_run_func(
     try:
         data = receiver.recv() if ingress else worker.deserialize(receiver.recv_bytes())
         logger.info("%s received %s", worker, data)
-        if batch > 1:
-            data = worker.forward([data])[0]
-        else:
-            data = worker.forward(data)
+        data = worker.forward([data])[0] if batch > 1 else worker.forward(data)
         logger.info("%s inference result: %s", worker, data)
         data = worker.serialize(data)
         sender.send_bytes(data)

--- a/mosec/mixin/plasma_worker.py
+++ b/mosec/mixin/plasma_worker.py
@@ -29,7 +29,7 @@ The plasma is deprecated in `pyarrow`. Please use Redis instead.
 
 import warnings
 from os import environ
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from mosec.worker import Worker
 
@@ -39,9 +39,6 @@ except ImportError:
     warnings.warn(
         "pyarrow is not installed. PlasmaShmMixin is not available.", ImportWarning
     )
-
-if TYPE_CHECKING:
-    from pyarrow import plasma
 
 
 _PLASMA_PATH_ENV = "MOSEC_INTERNAL_PLASMA_PATH"

--- a/mosec/runtime.py
+++ b/mosec/runtime.py
@@ -71,7 +71,6 @@ class Runtime:
             env: the environment variables to set before starting the process
             ipc_wrapper (IPCWrapper): IPC wrapper class to be initialized.
 
-
         Raises:
             TypeError: ipc_wrapper should inherit from `IPCWrapper`
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,10 @@ convention = "google"
 markers = [
     "shm: mark a test is related to shared memory",
 ]
+
+[tool.ruff]
+target-version = "py38"
+line-length = 88
+select = ["E", "F", "B", "I", "SIM", "TID", "PL"]
+[tool.ruff.pylint]
+max-args = 11

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""Build the package with Rust binary."""
+
 import os
 import shutil
 import subprocess
@@ -23,6 +25,7 @@ with open(os.path.join(here, "requirements/mixin.txt"), encoding="utf-8") as f:
 
 
 class RustExtension(Extension):
+    # pylint: disable=too-few-public-methods
     """Custom Extension class for rust"""
 
 
@@ -66,6 +69,7 @@ class RustBuildExt(_build_ext):
         if self.inplace:
             os.makedirs(os.path.dirname(libpath), exist_ok=True)
             shutil.copy(build_libpath, libpath)
+        return None
 
 
 setup(
@@ -89,5 +93,5 @@ setup(
     },
     zip_safe=False,
     ext_modules=ext_modules,  # type: ignore
-    cmdclass=dict(build_ext=RustBuildExt),  # type: ignore
+    cmdclass={"build_ext": RustBuildExt},
 )

--- a/tests/bad_req.py
+++ b/tests/bad_req.py
@@ -33,7 +33,7 @@ from tests.utils import wait_for_port_free, wait_for_port_open
 
 PORT = 5934
 URL = f"http://127.0.0.1:{PORT}/inference"
-REQ_NUM = int(os.getenv("CHAOS_REQUEST", 10000))
+REQ_NUM = int(os.getenv("CHAOS_REQUEST", "10000"))
 # set the thread number in case the CI server cannot get the real CPU number.
 THREAD = 8
 
@@ -44,9 +44,9 @@ def random_req(params, timeout):
 
 
 def main():
-    with concurrent.futures.ThreadPoolExecutor(max_workers=THREAD) as e:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=THREAD) as executor:
         futures = [
-            e.submit(
+            executor.submit(
                 random_req,
                 {"time": 0.1} if random() > 0.3 else {"hey": 0},
                 random() / 3.0,
@@ -57,7 +57,7 @@ def main():
         for future in concurrent.futures.as_completed(futures):
             try:
                 data = future.result()
-            except Exception as err:
+            except Exception as err:  # pylint: disable=broad-exception-caught
                 print("[x]", err)
             else:
                 print("[~]", data)

--- a/tests/mock_socket.py
+++ b/tests/mock_socket.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Mock socket interface."""
+
 
 class MockSocket:
     """Mock socket object used to test protocol."""
@@ -22,14 +24,15 @@ class MockSocket:
         self.timeout = None
 
     def recv(self, bufsize, flags=None) -> bytes:
+        """Receive data from buffer with size=bufsize."""
         data = self.buffer[:bufsize]
         self.buffer = self.buffer[bufsize:]
         return data
 
-    def recv_into(self, mv: memoryview, nbytes=1):
-        """nbytes=1 to avoid boundary condition"""
+    def recv_into(self, buf: memoryview, nbytes=1):
+        """Set nbytes=1 to avoid boundary condition."""
         chunk = self.buffer[:nbytes]
-        mv[:nbytes] = chunk
+        buf[:nbytes] = chunk
         self.buffer = self.buffer[nbytes:]
         return nbytes
 
@@ -46,6 +49,7 @@ class MockSocket:
         self.buffer += data
         return len(data)
 
+    # pylint: disable=no-self-use
     def getpeername(self):
         return ("peer-address", "peer-port")
 
@@ -56,10 +60,10 @@ class MockSocket:
         pass
 
 
-class socket:
+class Socket:
     AF_UNIX = "AF_UNIX"
     SOCK_STREAM = "SOCK_STREAM"
 
     @staticmethod
-    def socket(family=None, type=None, proto=None):
+    def socket(family=None, typ=None, protocol=None):
         return MockSocket(family)

--- a/tests/services/bad_service.py
+++ b/tests/services/bad_service.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Simulate bad requests:
+
+- Preprocess: raise ValidationError
+- Inference: raise random ServerError
+- client: disconnection
+"""
+
 import time
 from random import random
 from typing import List

--- a/tests/services/mixin_numbin_service.py
+++ b/tests/services/mixin_numbin_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test NumBin IPC mixin."""
+
 from typing import Dict, List
 
 import numpy as np

--- a/tests/services/mixin_typed_service.py
+++ b/tests/services/mixin_typed_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test MsgPack mixin."""
+
 from typing import Any, List
 
 from msgspec import Struct

--- a/tests/services/openapi_service.py
+++ b/tests/services/openapi_service.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test OpenAPI generated spec."""
 
 import sys
 from typing import Any, Dict, List, Type
@@ -66,7 +67,7 @@ class UntypedInference(TypedMsgPackMixin, Worker):
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Please specify the worker mapping. e.g. TypedPreprocess/TypedInference")
-        exit(1)
+        sys.exit(1)
 
     worker_mapping: Dict[str, Type[Worker]] = {
         "TypedPreprocess": TypedPreprocess,

--- a/tests/services/square_service.py
+++ b/tests/services/square_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test basic `forward` logic for single/concurrency request."""
+
 from typing import List
 
 from mosec import Server, Worker
@@ -23,7 +25,7 @@ class SquareService(Worker):
         try:
             result = [{"x": int(req["x"]) ** 2} for req in data]
         except KeyError as err:
-            raise ValidationError(err)
+            raise ValidationError(err) from err
         return result
 
 

--- a/tests/services/sse_service.py
+++ b/tests/services/sse_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test Server-Sent Event."""
+
 from mosec import Server, SSEWorker, ValidationError, Worker, get_logger
 
 logger = get_logger()
@@ -29,6 +31,7 @@ class Inference(SSEWorker):
     def forward(self, data):
         epoch = 5
         for _ in range(epoch):
+            # pylint: disable=consider-using-enumerate
             for j in range(len(data)):
                 self.send_stream_event(f"{data[j]}", index=j)
 

--- a/tests/services/timeout_service.py
+++ b/tests/services/timeout_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test worker timeout configuration."""
+
 import os
 import time
 from typing import Any
@@ -26,7 +28,7 @@ class SleepyInference(Worker):
 
     def forward(self, data: Any) -> Any:
         sleep_duration = float(os.environ["sleep_duration"])
-        logger.info(f"sleep_duration {sleep_duration}")
+        logger.info("sleep_duration %s", sleep_duration)
         time.sleep(sleep_duration)
         return data
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test multiprocessing logging configuration."""
+
 import logging
 
 from mosec.log import get_log_level, get_logger, set_logger

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""End-to-end service tests."""
+
 import random
 import re
 import shlex
@@ -150,18 +152,19 @@ def test_mixin_ipc_service(mosec_service, http_client):
     indirect=["mosec_service", "http_client"],
 )
 def test_mixin_typed_service(mosec_service, http_client):
+    text = b"hello mosec"
     resp = http_client.post(
         "/inference",
         content=msgpack.packb(
             {
                 "media": "text",
-                "binary": b"hello mosec",
+                "binary": text,
             }
         ),
     )
     assert resp.status_code == HTTPStatus.OK, resp
     assert resp.headers["content-type"] == "application/msgpack"
-    assert msgpack.unpackb(resp.content) == 11
+    assert msgpack.unpackb(resp.content) == len(text)
 
     # sleep long enough to make sure all the processes have been checked
     # ref to https://github.com/mosecorg/mosec/pull/379#issuecomment-1578304988
@@ -179,28 +182,28 @@ def test_mixin_typed_service(mosec_service, http_client):
     indirect=["mosec_service", "http_client"],
 )
 def test_sse_service(mosec_service, http_client):
-    round = 0
+    count = 0
     with connect_sse(
         http_client, "POST", "/sse_inference", json={"text": "mosec"}
     ) as event_source:
         for sse in event_source.iter_sse():
-            round += 1
+            count += 1
             assert sse.event == "message"
             assert sse.data == "mosec"
-    assert round == 5
+    assert count == 5
 
-    round = 0
+    count = 0
     with connect_sse(
         http_client, "POST", "/sse_inference", json={"bad": "req"}
     ) as event_source:
         for sse in event_source.iter_sse():
-            round += 1
+            count += 1
             assert sse.event == "error"
             assert sse.data == (
                 "SSE inference error: 422: Unprocessable Content: "
                 "request validation error: text is required"
             )
-    assert round == 1
+    assert count == 1
 
 
 @pytest.mark.parametrize(
@@ -213,29 +216,31 @@ def test_sse_service(mosec_service, http_client):
 def test_square_service_mp(mosec_service, http_client):
     threads = []
     for _ in range(20):
-        t = Thread(
+        thread = Thread(
             target=validate_square_service,
             args=(http_client, random.randint(-500, 500)),
         )
-        t.start()
-        threads.append(t)
-    for t in threads:
-        t.join()
+        thread.start()
+        threads.append(thread)
+    for thread in threads:
+        thread.join()
     assert_batch_larger_than_one(http_client)
     assert_empty_queue(http_client)
 
 
-def validate_square_service(http_client, x):
-    resp = http_client.post("/v1/inference", json={"x": x})
+def validate_square_service(http_client, num):
+    resp = http_client.post("/v1/inference", json={"x": num})
     assert resp.status_code == HTTPStatus.OK
-    assert resp.json()["x"] == x**2
+    assert resp.json()["x"] == num**2
 
 
 def assert_batch_larger_than_one(http_client):
+    def get_batch_size_int(text):
+        return int(text.split(" ")[-1])
+
     metrics = http_client.get("/metrics").content.decode()
-    bs = re.findall(r"batch_size_bucket.+", metrics)
-    get_bs_int = lambda x: int(x.split(" ")[-1])  # noqa
-    assert get_bs_int(bs[-1]) > get_bs_int(bs[0])
+    batch_size = re.findall(r"batch_size_bucket.+", metrics)
+    assert get_batch_size_int(batch_size[-1]) > get_batch_size_int(batch_size[0])
 
 
 def assert_empty_queue(http_client):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Test util functions."""
+
 from typing import List
 
 from msgspec import Struct

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Useful functions for test."""
+
 from __future__ import annotations
 
 import contextlib
@@ -23,7 +25,7 @@ import time
 from typing import TYPE_CHECKING, List, Tuple, Union
 
 if TYPE_CHECKING:
-    from tests.mock_socket import socket as mock_socket
+    from tests.mock_socket import Socket as mock_socket
 
 
 def imitate_controller_send(


### PR DESCRIPTION
- align the naming of `PyRuntimeManager` and `RsRuntimeManager`
- fix the test lint, close #136 

I tried `ruff` but I feel we can wait for it to be more mature.