### PR TITLE
docs: fix readthedocs build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,13 +17,16 @@ sphinx:
    configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
-# formats:
-#    - pdf
-#    - epub
+formats:
+   - pdf
+   - epub
 
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install
 python:
    install:
    - requirements: requirements/doc.txt
+   - method: pip
+     path: .


### PR DESCRIPTION
- ModuleNotFoundError in https://mosec.readthedocs.io/en/latest/reference/arguments.html
- https://mosec.readthedocs.io/en/latest/reference/interface.html doesn't contain all the interfaces, compared to https://mosecorg.github.io/mosec/reference/interface.html