### PR TITLE
chore: support macOS ARM release

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -22,6 +22,10 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-cache-
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
     - name: Get pip cache dir
       id: pip-cache-dir
       shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,8 +22,13 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/cache
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
       - name: Build
         run: |
+          python -m pip install pipx
           pipx run cibuildwheel
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ changelog = "https://github.com/mosecorg/mosec/releases"
 
 [tool.cibuildwheel]
 build-frontend = "build"
-skip = "cp36-*"
+skip = ["cp36-*", "*-musllinux_*", "pp*"]
 archs = ["auto64"]
 before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 environment = { PRODUCTION_MODE="yes", PATH="$PATH:$HOME/.cargo/bin", PIP_NO_CLEAN="yes" }


### PR DESCRIPTION
- fix #507 

This PR also disabled the build for "musllinux" and "PyPy" to save some storage space on PyPI.

I haven't tested the PyPy version. As for the musl, I don't know if it's necessary to keep it.