### PR TITLE
chore: fix typos and broken links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.9.3
+        uses: lycheeverse/lychee-action@v1
         with:
           fail: true
           args: --verbose --no-progress --format detailed .

--- a/docs/source/examples/embedding.md
+++ b/docs/source/examples/embedding.md
@@ -1,6 +1,6 @@
 # OpenAI compatible embedding service
 
-This example shows how to create an embedding service that is compatible with the [OpenAI API](https://platform.openai.com/docs/api-reference/embeddings/object).
+This example shows how to create an embedding service that is compatible with the [OpenAI API](https://platform.openai.com/docs/api-reference/embeddings).
 
 In this example, we use the embedding model from [HuggingFace LeaderBoard](https://huggingface.co/spaces/mteb/leaderboard).
 

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -174,7 +174,7 @@ class DryRunner:
         self.shutdown_notify.set()
 
     def run(self):
-        """Execute thr dry run process."""
+        """Execute the dry run process."""
         for endpoint, runtimes in self.router.items():
             logger.info(
                 "init dry run for endpoint %s with %s",

--- a/mosec/mixin/typed_worker.py
+++ b/mosec/mixin/typed_worker.py
@@ -38,11 +38,8 @@ class TypedMsgPackMixin(Worker):
         """Deserialize and validate request with msgspec."""
         import msgspec
 
-        if not self._input_typ:
+        if self._input_typ is None:
             self._input_typ = parse_func_type(self.forward, ParseTarget.INPUT)
-        if not issubclass(self._input_typ, msgspec.Struct):
-            # skip other annotation type
-            return super().deserialize(data)
 
         try:
             return msgspec.msgpack.decode(data, type=self._input_typ)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -35,7 +35,7 @@ const RESPONSE_EMPTY: &[u8] = b"no data provided";
 const RESPONSE_TOO_LARGE: &[u8] = b"request body is too large";
 const RESPONSE_SHUTDOWN: &[u8] = b"gracefully shutting down";
 const DEFAULT_RESPONSE_MIME: &str = "application/json";
-const DEFAULT_MAX_REQUEST_SIZE: usize = 10 * 1024 * 1024; // 10MB
+const DEFAULT_MAX_REQUEST_SIZE: usize = 10 * 1024 * 1024; // 10MiB
 
 fn build_response(status: StatusCode, content: Bytes) -> Response<Body> {
     Response::builder()


### PR DESCRIPTION
- msgspec can decode `msgspec.Struct/dataclass/attr/etc`, no need to check the class type