### PR TITLE
Fix rerank server error

### DIFF
--- a/examples/rerank/server.py
+++ b/examples/rerank/server.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 from os import environ
+from typing import List
 
 from msgspec import Struct
 from sentence_transformers import CrossEncoder
@@ -28,11 +27,11 @@ WORKER_NUM = int(environ.get("WORKER_NUM", 1))
 
 class Request(Struct, kw_only=True):
     query: str
-    docs: list[str]
+    docs: List[str]
 
 
 class Response(Struct, kw_only=True):
-    scores: list[float]
+    scores: List[float]
 
 
 class Encoder(TypedMsgPackMixin, Worker):


### PR DESCRIPTION
import __future__ annotation will break mosec.utils.parse_func_type. the __main__.Request would be changed to 'Request':
```
2024-06-15T00:55:54.001558Z  WARNING mosec::coordinator.py:300 [1869971]: Traceback (most recent call last):
   File "/home/user/mosec/lib/python3.10/site-packages/mosec/coordinator.py", line 274, in coordinate     data = [
   File "/home/user/mosec/lib/python3.10/site-packages/mosec/coordinator.py", line 275, in <listcomp>     self.decode(payload, state)
   File "/home/user/mosec/lib/python3.10/site-packages/mosec/coordinator.py", line 243, in decode     self.worker.deserialize(payload)
   File "/home/user/mosec/lib/python3.10/site-packages/mosec/mixin/typed_worker.py", line 45, in deserialize     return msgspec.msgpack.decode(data, type=self._input_typ)
   TypeError: Type ''Request'' is not supported
```