### PR TITLE
fix: annotations lazy evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "mosec"
-version = "0.8.4"
+version = "0.8.6"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosec"
-version = "0.8.4"
+version = "0.8.6"
 authors = ["Keming <kemingy94@gmail.com>", "Zichen <lkevinzc@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/mosec/server.py
+++ b/mosec/server.py
@@ -301,7 +301,7 @@ def generate_openapi(workers: List[Type[Worker]]):
             if not return_schema
             else {
                 "200": make_body(
-                    "Mosec Inference Result",
+                    "Mosec Inference Response",
                     response_worker_cls.resp_mime_type,
                     return_schema,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ changelog = "https://github.com/mosecorg/mosec/releases"
 
 [tool.cibuildwheel]
 build-frontend = "build"
-skip = ["cp36-*", "*-musllinux_*", "pp*"]
+skip = ["cp36-*", "cp37-*", "*-musllinux_*", "pp*"]
 archs = ["auto64"]
 before-all = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 environment = { PRODUCTION_MODE="yes", PATH="$PATH:$HOME/.cargo/bin", PIP_NO_CLEAN="yes" }
@@ -54,6 +54,7 @@ requires = ["setuptools>=45", "wheel", "setuptools_scm>=7.0"]
 write_to = "mosec/_version.py"
 
 [tool.mypy]
+python_version = "3.8"
 warn_redundant_casts = true
 warn_unreachable = true
 pretty = true

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,8 @@
 setuptools_scm>=7
 pytest>=6
 pytest-mock>=3.5
-mypy>=0.910
-pyright>=1.1.290
+mypy~=1.10.0
+pyright~=1.1.290
 ruff~=0.4.7
 pre-commit>=2.15.0
 msgpack>=1.0.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,9 +1,9 @@
 setuptools_scm>=7
 pytest>=6
 pytest-mock>=3.5
-mypy~=1.10.0
-pyright~=1.1.290
-ruff~=0.4.7
+mypy~=1.10
+pyright~=1.1
+ruff~=0.4
 pre-commit>=2.15.0
 msgpack>=1.0.5
 numpy>=1.24


### PR DESCRIPTION
- fix https://github.com/mosecorg/mosec/issues/535

`from __future__ import annotations` will enable the annotations lazy evaluation which changes all the annotations into strings. We have to eval these strings to get the real objects.