### PR TITLE
refactor: HTTPStautsCode -> HTTPStatusCode

### DIFF
--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -29,7 +29,7 @@ from typing import Any, Optional, Sequence, Type
 
 from mosec.errors import MosecError, MosecTimeoutError
 from mosec.log import get_internal_logger
-from mosec.protocol import HTTPStautsCode, Protocol
+from mosec.protocol import HTTPStatusCode, Protocol
 from mosec.worker import SSEWorker, Worker
 
 logger = get_internal_logger()
@@ -190,7 +190,7 @@ class Coordinator:
                 payloads = (text.encode(),)
                 ids = (self.current_ids[index],)
                 self.protocol.send(
-                    HTTPStautsCode.STREAM_EVENT, ids, (0,) * len(ids), payloads
+                    HTTPStatusCode.STREAM_EVENT, ids, (0,) * len(ids), payloads
                 )
                 self.semaphore.release()
             except queue.Empty:
@@ -286,7 +286,7 @@ class Coordinator:
                         "returned data size doesn't match the input data size:"
                         f"input({length})!=output({len(data)})"
                     )
-                status = HTTPStautsCode.OK
+                status = HTTPStatusCode.OK
                 payloads = [
                     self.encode(datum, state) for (datum, state) in zip(data, states)
                 ]
@@ -298,7 +298,7 @@ class Coordinator:
                 payloads = [f"{err.msg}: {err_msg}".encode()] * length
             except Exception:
                 logger.warning(traceback.format_exc().replace("\n", " "))
-                status = HTTPStautsCode.INTERNAL_ERROR
+                status = HTTPStatusCode.INTERNAL_ERROR
                 payloads = ["inference internal error".encode()] * length
 
             try:

--- a/mosec/errors.py
+++ b/mosec/errors.py
@@ -23,13 +23,13 @@ is raised; if the decoded data cannot pass the validation check (usually
 implemented by users), the `ValidationError` should be raised.
 """
 
-from mosec.protocol import HTTPStautsCode
+from mosec.protocol import HTTPStatusCode
 
 
 class MosecError(Exception):
     """Mosec basic exception."""
 
-    code: HTTPStautsCode = HTTPStautsCode.INTERNAL_ERROR
+    code: HTTPStatusCode = HTTPStatusCode.INTERNAL_ERROR
     msg: str = "mosec error"
 
 
@@ -42,7 +42,7 @@ class ClientError(MosecError):
     `HTTP 400 <https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400>`__.
     """
 
-    code = HTTPStautsCode.BAD_REQUEST
+    code = HTTPStatusCode.BAD_REQUEST
     msg = "bad request"
 
 
@@ -59,7 +59,7 @@ class ServerError(MosecError):
     an exception that is not inherited from `mosec.errors.MosecError`.
     """
 
-    code = HTTPStautsCode.INTERNAL_ERROR
+    code = HTTPStatusCode.INTERNAL_ERROR
     msg = "internal error"
 
 
@@ -100,7 +100,7 @@ class ValidationError(MosecError):
     in the response.
     """
 
-    code = HTTPStautsCode.VALIDATION_ERROR
+    code = HTTPStatusCode.VALIDATION_ERROR
     msg = "request validation error"
 
 
@@ -119,5 +119,5 @@ class MosecTimeoutError(BaseException):
     which isn't designed to break the working loop.
     """
 
-    code = HTTPStautsCode.TIMEOUT_ERROR
+    code = HTTPStatusCode.TIMEOUT_ERROR
     msg = "mosec timeout error"

--- a/mosec/protocol.py
+++ b/mosec/protocol.py
@@ -29,7 +29,7 @@ logger = get_internal_logger()
 IPC_LARGE_DATA_SIZE = 1024 * 1024  # set as 1 MB
 
 
-class HTTPStautsCode(IntFlag):
+class HTTPStatusCode(IntFlag):
     """HTTP status code flag."""
 
     OK = 1  # 200

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -34,7 +34,7 @@ import pytest
 
 from mosec.coordinator import PROTOCOL_TIMEOUT, Coordinator, State
 from mosec.mixin import MsgpackMixin
-from mosec.protocol import HTTPStautsCode, _recv_all
+from mosec.protocol import HTTPStatusCode, _recv_all
 from mosec.worker import Worker
 from tests.utils import imitate_controller_send
 
@@ -251,7 +251,7 @@ def test_echo_batch(base_test_config, test_data, worker, deserializer):
                 got_states.append(struct.unpack("!H", conn.recv(2))[0])
                 got_length = struct.unpack("!I", conn.recv(4))[0]
                 got_payloads.append(_recv_all(conn, got_length))
-            assert got_flag == HTTPStautsCode.OK
+            assert got_flag == HTTPStatusCode.OK
             assert got_ids == sent_ids
             assert got_states == [State.INGRESS | State.EGRESS] * len(sent_ids)
             assert all(


### PR DESCRIPTION
- There is a typo on variable name (`HTTPStautsCode`)