### PR TITLE
fix: replace pkg_resources with importlib

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,13 +49,13 @@ jobs:
       - name: install pyright
         run: npm install -g pyright
       - name: Lint
-        run: make lint
+        run: make lint semantic_lint
 
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
-      max-parallel: 10
+      max-parallel: 18
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest , macos-13, macos-14]
@@ -84,12 +84,18 @@ jobs:
           pip install -e .[dev,mixin]
           rustup component add clippy
           make dev
-      - name: Test
+      - name: Test unit
+        # ignore the mixin test for Python 3.13 since some of the dependencies are not ready
+        if: ${{ startsWith(matrix.python-version, '3.13')}}
         run: |
-          make semantic_lint test
+          make test_unit
+      - name: Test
+        if: ${{ !startsWith(matrix.python-version, '3.13')}}
+        run: |
+          make test
       - name: Test shm in Linux
         # ignore the shm test for Python 3.12 since pyarrow doesn't have py3.12 wheel with version < 12
-        if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, '3.12') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.python-version, '3.12') && !startsWith(matrix.python-version, '3.13') }}
         run: |
           sudo apt update && sudo apt install redis
           make test_shm

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest , macos-13, macos-14]
         exclude:
           - python-version: "3.8"
@@ -73,6 +73,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,12 +78,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-      - name: Install dependencies
+      - name: Install components
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev,mixin]
           rustup component add clippy
-          make dev
       - name: Test unit
         # ignore the mixin test for Python 3.13 since some of the dependencies are not ready
         if: ${{ startsWith(matrix.python-version, '3.13')}}

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,13 @@ dev:
 	pip install -e .
 
 test: dev
-	echo "Running tests for the main logic"
+	echo "Running tests for the main logic and mixin(!shm)"
 	pytest tests -vv -s -m "not shm"
+	RUST_BACKTRACE=1 cargo test -vv
+
+test_unit: dev
+	echo "Running tests for the main logic"
+	pytest -vv -s tests/test_log.py tests/test_utils.py tests/test_protocol.py tests/test_coordinator.py
 	RUST_BACKTRACE=1 cargo test -vv
 
 test_shm: dev

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,17 @@ dev:
 	cargo build
 	@mkdir -p mosec/bin
 	@cp ./target/debug/mosec mosec/bin/mosec
-	pip install -e .
+	pip install -e .[dev]
 
 test: dev
+	@pip install -q -r requirements/mixin.txt
 	echo "Running tests for the main logic and mixin(!shm)"
 	pytest tests -vv -s -m "not shm"
 	RUST_BACKTRACE=1 cargo test -vv
 
 test_unit: dev
 	echo "Running tests for the main logic"
-	pytest -vv -s tests/test_log.py tests/test_utils.py tests/test_protocol.py tests/test_coordinator.py
+	pytest -vv -s tests/test_log.py tests/test_protocol.py tests/test_coordinator.py
 	RUST_BACKTRACE=1 cargo test -vv
 
 test_shm: dev

--- a/mosec/log.py
+++ b/mosec/log.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, MutableMapping
 
 from mosec.args import get_log_level
@@ -42,7 +42,7 @@ class MosecFormat(logging.Formatter):
 
     def formatTime(self, record: logging.LogRecord, datefmt=None) -> str:
         """Convert to datetime with timezone."""
-        time = datetime.fromtimestamp(record.created).utcnow()
+        time = datetime.fromtimestamp(record.created).now(timezone.utc)
         return datetime.strftime(time, datefmt if datefmt else self.default_time_format)
 
 

--- a/mosec/runtime.py
+++ b/mosec/runtime.py
@@ -16,13 +16,23 @@
 
 import multiprocessing as mp
 import subprocess
-from importlib.resources import files as importlib_files  # type: ignore
+import sys
 from multiprocessing.context import ForkContext, SpawnContext
 from multiprocessing.process import BaseProcess
 from multiprocessing.synchronize import Event
 from pathlib import Path
 from time import monotonic, sleep
 from typing import Callable, Dict, Iterable, List, Optional, Type, Union, cast
+
+if sys.version_info >= (3, 9):
+    from importlib.resources import files as importlib_files
+else:
+    from pkg_resources import resource_filename
+
+    def importlib_files(package: str) -> Path:
+        """Get the resource file path."""
+        return Path(resource_filename(package, ""))
+
 
 from mosec.coordinator import Coordinator
 from mosec.env import env_var_context, validate_env, validate_int_ge
@@ -238,7 +248,7 @@ class RsRuntimeManager:
         """
         self.process: Optional[subprocess.Popen] = None
 
-        self.server_path = importlib_files(anchor="mosec") / "bin" / "mosec"
+        self.server_path = importlib_files("mosec") / "bin" / "mosec"
         self.timeout = timeout
 
     def halt(self):

--- a/mosec/runtime.py
+++ b/mosec/runtime.py
@@ -16,14 +16,13 @@
 
 import multiprocessing as mp
 import subprocess
+from importlib.resources import files as importlib_files  # type: ignore
 from multiprocessing.context import ForkContext, SpawnContext
 from multiprocessing.process import BaseProcess
 from multiprocessing.synchronize import Event
 from pathlib import Path
 from time import monotonic, sleep
 from typing import Callable, Dict, Iterable, List, Optional, Type, Union, cast
-
-import pkg_resources
 
 from mosec.coordinator import Coordinator
 from mosec.env import env_var_context, validate_env, validate_int_ge
@@ -239,9 +238,7 @@ class RsRuntimeManager:
         """
         self.process: Optional[subprocess.Popen] = None
 
-        self.server_path = Path(
-            pkg_resources.resource_filename("mosec", "bin"), "mosec"
-        )
+        self.server_path = importlib_files(anchor="mosec") / "bin" / "mosec"
         self.timeout = timeout
 
     def halt(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ license = {text = "Apache-2.0"}
 keywords = ["machine learning", "deep learning", "model serving"]
 dynamic = ["version"]
 requires-python = ">=3.8"
+dependencies = [
+    "importlib_resources >= 5.10; python_version < '3.12'",
+]
 classifiers = [
     "Environment :: GPU",
     "Intended Audience :: Developers",
@@ -80,8 +83,6 @@ markers = [
     "shm: mark a test is related to shared memory",
 ]
 
-[tool.ruff]
-target-version = "py38"
 [tool.ruff.lint]
 select = ["E", "F", "G", "B", "I", "SIM", "TID", "PL", "RUF", "D"]
 ignore = ["E501", "D203", "D213"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ license = {text = "Apache-2.0"}
 keywords = ["machine learning", "deep learning", "model serving"]
 dynamic = ["version"]
 requires-python = ">=3.8"
-dependencies = [
-    "importlib_resources >= 5.10; python_version < '3.12'",
-]
+dependencies = []
 classifiers = [
     "Environment :: GPU",
     "Intended Audience :: Developers",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@ mypy~=1.11
 pyright~=1.1
 ruff~=0.6
 pre-commit>=2.15.0
-msgpack>=1.0.5
 numpy<2
 httpx==0.27.2
 httpx-sse==0.4.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,6 +5,5 @@ mypy~=1.11
 pyright~=1.1
 ruff~=0.6
 pre-commit>=2.15.0
-numpy<2
 httpx==0.27.2
 httpx-sse==0.4.0

--- a/requirements/mixin.txt
+++ b/requirements/mixin.txt
@@ -3,4 +3,4 @@ msgspec>=0.15.0
 numbin>=0.5.0
 pyarrow>=0.6.1,<12; python_version < "3.12"
 redis>=4.0.0
-numpy
+numpy<2 # pyarrow legacy dependency

--- a/requirements/mixin.txt
+++ b/requirements/mixin.txt
@@ -3,3 +3,4 @@ msgspec>=0.15.0
 numbin>=0.5.0
 pyarrow>=0.6.1,<12; python_version < "3.12"
 redis>=4.0.0
+numpy

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -29,11 +29,9 @@ from multiprocessing.context import ForkContext, SpawnContext
 from os.path import join
 from typing import Union, cast
 
-import msgpack  # type: ignore
 import pytest
 
 from mosec.coordinator import PROTOCOL_TIMEOUT, Coordinator, State
-from mosec.mixin import MsgpackMixin
 from mosec.protocol import HTTPStatusCode, _recv_all
 from mosec.worker import Worker
 from tests.utils import imitate_controller_send
@@ -63,10 +61,6 @@ class CleanDirContext(ContextDecorator):
 class EchoWorkerJSON(Worker):
     def forward(self, data):
         return data
-
-
-class EchoWorkerMsgPack(MsgpackMixin, EchoWorkerJSON):
-    pass
 
 
 @pytest.fixture
@@ -191,14 +185,6 @@ def test_incorrect_socket_file(mocker, base_test_config, caplog):
             ],
             EchoWorkerJSON,
             json.loads,
-        ),
-        (
-            [
-                msgpack.packb({"rid": "147982364", "data": b"im_bytes"}),
-                msgpack.packb({"rid": "147982831", "data": b"another_im_bytes"}),
-            ],
-            EchoWorkerMsgPack,
-            msgpack.unpackb,
         ),
     ],
 )


### PR DESCRIPTION
- related to https://github.com/conda-forge/mosec-feedstock/pull/14

We already release 3.13 since it has compatible ABI as the final release. (this is the default behavior for cibuildwheel).

However, `pkg_resources` is deprecated.

- https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename
