### PR TITLE
[Docs] Add source_edit_link to point to the correct path

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,7 @@ html_favicon = "https://user-images.githubusercontent.com/38581401/134798617-010
 html_theme_options = {
     "sidebar_hide_name": True,
     "navigation_with_keys": True,
-    "source_edit_link": "https://www.github.com/mosecorg/mosec/edit/main/docs/source/{filename}",
-    "source_view_link": "https://www.github.com/mosecorg/mosec/blob/main/docs/source/{filename}",
+    "source_repository": "https://github.com/mosecorg/mosec",
+    "source_branch": "main",
+    "source_directory": "docs/source",
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,4 +60,5 @@ html_favicon = "https://user-images.githubusercontent.com/38581401/134798617-010
 html_theme_options = {
     "sidebar_hide_name": True,
     "navigation_with_keys": True,
+    "source_edit_link": "https://www.github.com/mosecorg/mosec/edit/main/docs/source/{filename}"
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,5 +60,6 @@ html_favicon = "https://user-images.githubusercontent.com/38581401/134798617-010
 html_theme_options = {
     "sidebar_hide_name": True,
     "navigation_with_keys": True,
-    "source_edit_link": "https://www.github.com/mosecorg/mosec/edit/main/docs/source/{filename}"
+    "source_edit_link": "https://www.github.com/mosecorg/mosec/edit/main/docs/source/{filename}",
+    "source_view_link": "https://www.github.com/mosecorg/mosec/blob/main/docs/source/{filename}",
 }


### PR DESCRIPTION
Clicking on `edit this page` button on top of the page when not in the `latest` version of the docs redirects to a non-existing page
![image](https://github.com/user-attachments/assets/ed25b66c-1ab8-4f95-8e50-b4d2b1304fc5)
![image](https://github.com/user-attachments/assets/c79061fd-01f7-4acb-bc67-37f7cea35dad)
