### PR TITLE
chore: upgrade lychee action and accept 403 forbidden

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@v2
         with:
           fail: true
-          args: --verbose --no-progress --format detailed .
+          args: --accept '100..=103,200..=299, 403' --verbose --no-progress --format detailed .


### PR DESCRIPTION
OpenAI forbid `lychee`, let's ignore the 403 error for now.

- https://github.com/lycheeverse/lychee/issues/1157