### PR TITLE
fix: align registered Runtime & appended Worker timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
+checksum = "d615619615a650c571269c00dca41db04b9210037fa76ed8239f70404ab56985"
 dependencies = [
  "flate2",
  "futures-core",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytes"
@@ -198,9 +198,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "concurrent-queue"
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "http"
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "bytes",
  "futures-core",
@@ -699,9 +699,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
 dependencies = [
  "zlib-rs",
 ]
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "mosec"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-channel",
  "async-stream",
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustversion"
@@ -1169,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -1191,9 +1191,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1328,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1382,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1770,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosec"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Keming <kemingy94@gmail.com>", "Zichen <lkevinzc@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -49,8 +49,8 @@ serde = "1.0"
 serde_json = "1.0"
 utoipa = "5.3"
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
-tower = "0.5.1"
-tower-http = { version = "0.6.4", features = [
+tower = "0.5.2"
+tower-http = { version = "0.6.6", features = [
   "compression-zstd",
   "decompression-zstd",
   "compression-gzip",

--- a/build.envd
+++ b/build.envd
@@ -29,8 +29,7 @@ def jax():
 
 def build():
     base(dev=True, image="ubuntu:22.04")
-    install.conda()
-    install.python()
+    install.uv()
     rust()
     runtime.init(["make install"])
 

--- a/mosec/coordinator.py
+++ b/mosec/coordinator.py
@@ -50,11 +50,11 @@ PROTOCOL_TIMEOUT = 2.0
 
 
 @contextmanager
-def set_mosec_timeout(duration: int):
+def set_mosec_timeout(duration: float):
     """Context manager to set a timeout for a code block.
 
     Args:
-        duration (float): the duration in seconds before timing out
+        duration: the duration in seconds before timing out
 
     """
 
@@ -64,11 +64,11 @@ def set_mosec_timeout(duration: int):
         )
 
     signal.signal(signal.SIGALRM, handler)
-    signal.alarm(duration)
+    signal.setitimer(signal.ITIMER_REAL, duration)
     try:
         yield
     finally:
-        signal.alarm(0)
+        signal.setitimer(signal.ITIMER_REAL, 0)
 
 
 class FakeSemaphore:
@@ -108,7 +108,7 @@ class Coordinator:
         socket_prefix: str,
         stage_name: str,
         worker_id: int,
-        timeout: int,
+        timeout: float,
     ):
         """Initialize the mosec coordinator.
 

--- a/mosec/env.py
+++ b/mosec/env.py
@@ -85,6 +85,14 @@ def validate_int_ge(number, name, threshold=1):
     assert number >= threshold, f"{name} must be no less than {threshold}"
 
 
+def validate_float_ge(number, name, threshold=0.0):
+    """Validate float number is greater than threshold."""
+    assert isinstance(number, float), (
+        f"{name} must be float but you give {type(number)}"
+    )
+    assert number >= threshold, f"{name} must be no less than {threshold}"
+
+
 def validate_str_dict(dictionary: Dict):
     """Validate keys and values of the dictionary is string type."""
     for key, value in dictionary.items():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -110,13 +110,13 @@ def test_square_service(mosec_service, http_client):
     "mosec_service,http_client,status_code",
     [
         pytest.param(
-            "timeout_service --sleep-duration 1.5 --worker-timeout 1",
+            "timeout_service --sleep-duration 1 --worker-timeout 0.5",
             None,
             HTTPStatus.REQUEST_TIMEOUT,
             id="worker-forward-trigger-worker-timeout",
         ),
         pytest.param(
-            "timeout_service --sleep-duration 1.0 --worker-timeout 2",
+            "timeout_service --sleep-duration 0.5 --worker-timeout 1",
             None,
             HTTPStatus.OK,
             id="normal-request-within-worker-timeout",
@@ -126,6 +126,18 @@ def test_square_service(mosec_service, http_client):
             None,
             HTTPStatus.REQUEST_TIMEOUT,
             id="worker-forward-trigger-service-timeout",
+        ),
+        pytest.param(
+            "timeout_service --sleep-duration 1 --worker-timeout 0.5",
+            None,
+            HTTPStatus.REQUEST_TIMEOUT,
+            id="worker-forward-trigger-worker-runtime-timeout",
+        ),
+        pytest.param(
+            "timeout_service --sleep-duration 0.5 --worker-timeout 1",
+            None,
+            HTTPStatus.OK,
+            id="normal-request-within-worker-runtime-timeout",
         ),
     ],
     indirect=["mosec_service", "http_client"],


### PR DESCRIPTION
- fix https://github.com/mosecorg/mosec/issues/651
- use `signal.setitimer` instead of `signal.alarm`