### PR TITLE
feat: configurable max request size

### DIFF
--- a/mosec/args.py
+++ b/mosec/args.py
@@ -55,7 +55,8 @@ def build_arguments_parser() -> argparse.ArgumentParser:
         description="Mosec Server Configurations",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         epilog="The following arguments can be set through environment variables: ("
-        "path, capacity, timeout, address, port, namespace, debug, log_level, dry_run"
+        "path, capacity, timeout, address, port, namespace, debug, log_level, dry_run, "
+        "max_request_size"
         "). Note that the environment variable should start with `MOSEC_` with upper "
         "case. For example: `MOSEC_PORT=8080 MOSEC_TIMEOUT=5000 python main.py`.",
     )
@@ -139,6 +140,14 @@ def build_arguments_parser() -> argparse.ArgumentParser:
         "--compression",
         help="Enable `zstd` & `gzip` compression for the request & response",
         action="store_true",
+    )
+
+    parser.add_argument(
+        "--max-request-size",
+        help="Maximum request body size in bytes. Requests larger than this "
+        "will be rejected with status 413",
+        type=int,
+        default=10 * 1024 * 1024,
     )
 
     return parser

--- a/mosec/env.py
+++ b/mosec/env.py
@@ -33,6 +33,7 @@ MOSEC_ENV_CONFIG = {
     "debug": bool,
     "dry_run": bool,
     "log_level": str,
+    "max_request_size": int,
 }
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,8 @@ pub(crate) struct Config {
     pub log_level: String,
     // `zstd` & `gzip` compression
     pub compression: bool,
+    // maximum request body size in bytes
+    pub max_request_size: usize,
     pub runtimes: Vec<Runtime>,
     pub routes: Vec<Route>,
 }
@@ -82,6 +84,7 @@ impl Default for Config {
             namespace: String::from("mosec_service"),
             log_level: String::from("info"),
             compression: false,
+            max_request_size: 10 * 1024 * 1024,
             runtimes: vec![Runtime {
                 max_batch_size: 64,
                 max_wait_time: 3000,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use crate::apidoc::MosecOpenAPI;
 use crate::config::Config;
 use crate::layouts::{ColoredLayout, JsonLayout};
 use crate::metrics::{METRICS, Metrics};
-use crate::routes::{RustAPIDoc, index, inference, metrics, sse_inference};
+use crate::routes::{AppState, RustAPIDoc, index, inference, metrics, sse_inference};
 use crate::tasks::{TASK_MANAGER, TaskManager};
 
 async fn shutdown_signal() {
@@ -79,10 +79,13 @@ async fn run(conf: &Config) {
 
     let metrics_instance = Metrics::init_with_namespace(&conf.namespace, conf.timeout);
     METRICS.set(metrics_instance).unwrap();
-    let mut task_manager = TaskManager::new(conf.timeout, conf.max_request_size);
+    let mut task_manager = TaskManager::new(conf.timeout);
     let barrier = task_manager.init_from_config(conf);
     TASK_MANAGER.set(task_manager).unwrap();
 
+    let app_state = AppState {
+        max_request_size: conf.max_request_size,
+    };
     let mut router = Router::new()
         .merge(SwaggerUi::new("/openapi/swagger").url("/openapi/metadata.json", doc.api))
         .route("/", get(index))
@@ -103,6 +106,8 @@ async fn run(conf: &Config) {
                 .layer(CompressionLayer::new()),
         );
     }
+
+    let router = router.with_state(app_state);
 
     // wait until each stage has at least one worker alive
     barrier.wait().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ async fn run(conf: &Config) {
 
     let metrics_instance = Metrics::init_with_namespace(&conf.namespace, conf.timeout);
     METRICS.set(metrics_instance).unwrap();
-    let mut task_manager = TaskManager::new(conf.timeout);
+    let mut task_manager = TaskManager::new(conf.timeout, conf.max_request_size);
     let barrier = task_manager.init_from_config(conf);
     TASK_MANAGER.set(task_manager).unwrap();
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use axum::body::{Body, to_bytes};
+use axum::extract::State;
 use axum::http::header::{CONTENT_TYPE, HeaderValue};
 use axum::http::{Request, Response, StatusCode, Uri};
 use axum::response::IntoResponse;
@@ -23,8 +24,6 @@ use bytes::Bytes;
 use log::warn;
 use prometheus_client::encoding::text::encode;
 use utoipa::OpenApi;
-
-use axum::extract::State;
 
 use crate::errors::ServiceError;
 use crate::metrics::{CodeLabel, DURATION_LABEL, Metrics, REGISTRY};

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -24,9 +24,16 @@ use log::warn;
 use prometheus_client::encoding::text::encode;
 use utoipa::OpenApi;
 
+use axum::extract::State;
+
 use crate::errors::ServiceError;
 use crate::metrics::{CodeLabel, DURATION_LABEL, Metrics, REGISTRY};
 use crate::tasks::{TaskCode, TaskManager};
+
+#[derive(Clone)]
+pub(crate) struct AppState {
+    pub(crate) max_request_size: usize,
+}
 
 const SERVER_INFO: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 const RESPONSE_DEFAULT: &[u8] = b"MOSEC service";
@@ -97,7 +104,11 @@ pub(crate) async fn metrics() -> Response<Body> {
         (status = StatusCode::TOO_MANY_REQUESTS, description = "TOO_MANY_REQUESTS"),
     ),
 )]
-pub(crate) async fn inference(uri: Uri, req: Request<Body>) -> Response<Body> {
+pub(crate) async fn inference(
+    State(state): State<AppState>,
+    uri: Uri,
+    req: Request<Body>,
+) -> Response<Body> {
     let task_manager = TaskManager::global();
     let endpoint = uri.path();
     let mime = match task_manager.get_mime_type(endpoint) {
@@ -112,7 +123,7 @@ pub(crate) async fn inference(uri: Uri, req: Request<Body>) -> Response<Body> {
         );
     }
 
-    let data = match to_bytes(req.into_body(), task_manager.max_request_size).await {
+    let data = match to_bytes(req.into_body(), state.max_request_size).await {
         Ok(data) => data,
         Err(err) => {
             warn!(err:?; "failed to read request body (too large)");
@@ -191,7 +202,11 @@ pub(crate) async fn inference(uri: Uri, req: Request<Body>) -> Response<Body> {
         (status = StatusCode::TOO_MANY_REQUESTS, description = "TOO_MANY_REQUESTS"),
     ),
 )]
-pub(crate) async fn sse_inference(uri: Uri, req: Request<Body>) -> Response<Body> {
+pub(crate) async fn sse_inference(
+    State(state): State<AppState>,
+    uri: Uri,
+    req: Request<Body>,
+) -> Response<Body> {
     let task_manager = TaskManager::global();
     let endpoint = uri.path();
 
@@ -203,7 +218,7 @@ pub(crate) async fn sse_inference(uri: Uri, req: Request<Body>) -> Response<Body
             .into_response();
     }
 
-    let data = match to_bytes(req.into_body(), task_manager.max_request_size).await {
+    let data = match to_bytes(req.into_body(), state.max_request_size).await {
         Ok(data) => data,
         Err(err) => {
             warn!(err:?; "failed to read request body (too large)");

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -30,17 +30,18 @@ use crate::errors::ServiceError;
 use crate::metrics::{CodeLabel, DURATION_LABEL, Metrics, REGISTRY};
 use crate::tasks::{TaskCode, TaskManager};
 
-#[derive(Clone)]
-pub(crate) struct AppState {
-    pub(crate) max_request_size: usize,
-}
-
 const SERVER_INFO: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 const RESPONSE_DEFAULT: &[u8] = b"MOSEC service";
 const RESPONSE_EMPTY: &[u8] = b"no data provided";
 const RESPONSE_TOO_LARGE: &[u8] = b"request body is too large";
 const RESPONSE_SHUTDOWN: &[u8] = b"gracefully shutting down";
 const DEFAULT_RESPONSE_MIME: &str = "application/json";
+
+#[derive(Clone)]
+pub(crate) struct AppState {
+    pub(crate) max_request_size: usize,
+}
+
 fn build_response(status: StatusCode, content: Bytes) -> Response<Body> {
     Response::builder()
         .status(status)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -34,8 +34,6 @@ const RESPONSE_EMPTY: &[u8] = b"no data provided";
 const RESPONSE_TOO_LARGE: &[u8] = b"request body is too large";
 const RESPONSE_SHUTDOWN: &[u8] = b"gracefully shutting down";
 const DEFAULT_RESPONSE_MIME: &str = "application/json";
-const DEFAULT_MAX_REQUEST_SIZE: usize = 10 * 1024 * 1024; // 10MiB
-
 fn build_response(status: StatusCode, content: Bytes) -> Response<Body> {
     Response::builder()
         .status(status)
@@ -114,7 +112,7 @@ pub(crate) async fn inference(uri: Uri, req: Request<Body>) -> Response<Body> {
         );
     }
 
-    let data = match to_bytes(req.into_body(), DEFAULT_MAX_REQUEST_SIZE).await {
+    let data = match to_bytes(req.into_body(), task_manager.max_request_size).await {
         Ok(data) => data,
         Err(err) => {
             warn!(err:?; "failed to read request body (too large)");
@@ -205,7 +203,7 @@ pub(crate) async fn sse_inference(uri: Uri, req: Request<Body>) -> Response<Body
             .into_response();
     }
 
-    let data = match to_bytes(req.into_body(), DEFAULT_MAX_REQUEST_SIZE).await {
+    let data = match to_bytes(req.into_body(), task_manager.max_request_size).await {
         Ok(data) => data,
         Err(err) => {
             warn!(err:?; "failed to read request body (too large)");

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -93,6 +93,7 @@ pub(crate) struct TaskManager {
     current_id: Mutex<u32>,
     senders: HashMap<String, Vec<async_channel::Sender<u32>>>,
     mime_types: HashMap<String, String>,
+    pub max_request_size: usize,
     shutdown: AtomicBool,
 }
 
@@ -103,7 +104,7 @@ impl TaskManager {
         TASK_MANAGER.get().expect("task manager is not initialized")
     }
 
-    pub(crate) fn new(timeout: u64) -> Self {
+    pub(crate) fn new(timeout: u64, max_request_size: usize) -> Self {
         Self {
             table: Mutex::new(HashMap::new()),
             notifiers: Mutex::new(HashMap::new()),
@@ -112,6 +113,7 @@ impl TaskManager {
             current_id: Mutex::new(0),
             senders: HashMap::new(),
             mime_types: HashMap::new(),
+            max_request_size,
             shutdown: AtomicBool::new(false),
         }
     }
@@ -429,7 +431,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_add_new_task() {
-        let mut task_manager = TaskManager::new(1000);
+        let mut task_manager = TaskManager::new(1000, 10 * 1024 * 1024);
         task_manager.init_from_config(&Config::default());
         let (id, _rx) = task_manager
             .add_new_task(Bytes::from_static(b"hello"), DEFAULT_ENDPOINT)
@@ -455,7 +457,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_timeout() {
-        let mut task_manager = TaskManager::new(1);
+        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
         task_manager.init_from_config(&Config::default());
 
         // wait until this task timeout
@@ -467,7 +469,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_too_many_request() {
-        let mut task_manager = TaskManager::new(1);
+        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
         let mut config = Config::default();
         // capacity > 0
         config.capacity = 1;
@@ -487,7 +489,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_graceful_shutdown() {
-        let mut task_manager = TaskManager::new(1);
+        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
         task_manager.init_from_config(&Config::default());
         assert!(!task_manager.is_shutdown());
         task_manager.shutdown().await;
@@ -496,7 +498,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_graceful_shutdown_after_timeout() {
-        let mut task_manager = TaskManager::new(10);
+        let mut task_manager = TaskManager::new(10, 10 * 1024 * 1024);
         task_manager.init_from_config(&Config::default());
         {
             // block with one task in the channel
@@ -516,7 +518,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_get_and_update_task() {
-        let mut task_manager = TaskManager::new(1);
+        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
         task_manager.init_from_config(&Config::default());
 
         // add some tasks to the table

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -93,7 +93,6 @@ pub(crate) struct TaskManager {
     current_id: Mutex<u32>,
     senders: HashMap<String, Vec<async_channel::Sender<u32>>>,
     mime_types: HashMap<String, String>,
-    pub max_request_size: usize,
     shutdown: AtomicBool,
 }
 
@@ -104,7 +103,7 @@ impl TaskManager {
         TASK_MANAGER.get().expect("task manager is not initialized")
     }
 
-    pub(crate) fn new(timeout: u64, max_request_size: usize) -> Self {
+    pub(crate) fn new(timeout: u64) -> Self {
         Self {
             table: Mutex::new(HashMap::new()),
             notifiers: Mutex::new(HashMap::new()),
@@ -113,7 +112,6 @@ impl TaskManager {
             current_id: Mutex::new(0),
             senders: HashMap::new(),
             mime_types: HashMap::new(),
-            max_request_size,
             shutdown: AtomicBool::new(false),
         }
     }
@@ -431,7 +429,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_add_new_task() {
-        let mut task_manager = TaskManager::new(1000, 10 * 1024 * 1024);
+        let mut task_manager = TaskManager::new(1000);
         task_manager.init_from_config(&Config::default());
         let (id, _rx) = task_manager
             .add_new_task(Bytes::from_static(b"hello"), DEFAULT_ENDPOINT)
@@ -457,7 +455,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_timeout() {
-        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
+        let mut task_manager = TaskManager::new(1);
         task_manager.init_from_config(&Config::default());
 
         // wait until this task timeout
@@ -469,7 +467,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_too_many_request() {
-        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
+        let mut task_manager = TaskManager::new(1);
         let mut config = Config::default();
         // capacity > 0
         config.capacity = 1;
@@ -489,7 +487,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_graceful_shutdown() {
-        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
+        let mut task_manager = TaskManager::new(1);
         task_manager.init_from_config(&Config::default());
         assert!(!task_manager.is_shutdown());
         task_manager.shutdown().await;
@@ -498,7 +496,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_graceful_shutdown_after_timeout() {
-        let mut task_manager = TaskManager::new(10, 10 * 1024 * 1024);
+        let mut task_manager = TaskManager::new(10);
         task_manager.init_from_config(&Config::default());
         {
             // block with one task in the channel
@@ -518,7 +516,7 @@ mod tests {
 
     #[tokio::test]
     async fn task_manager_get_and_update_task() {
-        let mut task_manager = TaskManager::new(1, 10 * 1024 * 1024);
+        let mut task_manager = TaskManager::new(1);
         task_manager.init_from_config(&Config::default());
 
         // add some tasks to the table

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -402,3 +402,20 @@ def test_compression_service(mosec_service, http_client):
     )
     assert resp.status_code == HTTPStatus.OK, resp
     assert resp.json() == expect, resp.content
+
+
+@pytest.mark.parametrize(
+    "mosec_service, http_client",
+    [
+        pytest.param("square_service --max-request-size 64", "", id="max-request-size"),
+    ],
+    indirect=["mosec_service", "http_client"],
+)
+def test_max_request_size(mosec_service, http_client):
+    # small request should succeed
+    resp = http_client.post("/inference", json={"x": 2})
+    assert resp.status_code == HTTPStatus.OK
+
+    # request larger than 64 bytes should be rejected
+    resp = http_client.post("/inference", json={"x": 2, "padding": "a" * 100})
+    assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -416,6 +416,6 @@ def test_max_request_size(mosec_service, http_client):
     resp = http_client.post("/inference", json={"x": 2})
     assert resp.status_code == HTTPStatus.OK
 
-    # request larger than 64 bytes should be rejected
+    # request larger than 64 bytes should return status code 413
     resp = http_client.post("/inference", json={"x": 2, "padding": "a" * 100})
     assert resp.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE


### PR DESCRIPTION
Resolves #701 

## Summary
Current hardcoded `DEFAULT_MAX_REQUEST_SIZE` does not allow for fine tuning without rebuilding the code, reducing operational flexibility
This PR makes it a parameter, keeping the default value intact

## Changes
`max_request_size` is implemented the same way `timeout` is (since they are both a property of taskmanager):
- `max_request_size` parameter added to `TaskManager` constructor
- added to config struct
- `--max-request-size` added to CLI 
- additionally a test is implemented to check that requests larger than the value result in 413   



