### PR TITLE
chore: use uv pkg ecosystem for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"
@@ -31,7 +31,7 @@ updates:
       semver-minor-days: 15
       semver-patch-days: 7
     commit-message:
-      prefix: "chore(pip)"
+      prefix: "chore(py)"
     groups:
       all-pips:
         patterns:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "mosec"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-channel",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mosec"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["Keming <kemingy94@gmail.com>", "Zichen <lkevinzc@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
- bump mosec version