### PR TITLE
feat: collect metrics in dry run

### DIFF
--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -17,11 +17,12 @@
 from __future__ import annotations
 
 import json
+import resource
 import signal
 import sys
 import time
 from multiprocessing.context import SpawnContext, SpawnProcess
-from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 
 from mosec.env import env_var_context
 from mosec.log import get_internal_logger
@@ -35,6 +36,64 @@ if TYPE_CHECKING:
 logger = get_internal_logger()
 
 
+def _get_memory_metrics() -> Dict[str, Any]:
+    """Collect memory metrics using stdlib resource module."""
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    rss = usage.ru_maxrss
+    # On macOS, ru_maxrss is in bytes; on Linux, it's in kilobytes
+    if sys.platform != "darwin":
+        rss *= 1024
+    return {"max_rss_bytes": rss}
+
+
+def _try_reset_gpu_peak_memory():
+    """Reset GPU peak memory stats if torch.cuda is available."""
+    try:
+        import torch  # pylint: disable=import-outside-toplevel
+
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+    except ImportError:
+        pass
+
+
+def _get_gpu_metrics() -> Dict[str, Any]:
+    """Collect GPU metrics if available (torch.cuda or pynvml)."""
+    metrics: Dict[str, Any] = {}
+    try:
+        import torch  # pylint: disable=import-outside-toplevel
+
+        if torch.cuda.is_available():
+            metrics["gpu_peak_memory_bytes"] = torch.cuda.max_memory_allocated()
+    except ImportError:
+        pass
+
+    try:
+        # pylint: disable=import-outside-toplevel
+        from pynvml import (
+            nvmlDeviceGetHandleByIndex,
+            nvmlDeviceGetMemoryInfo,
+            nvmlDeviceGetUtilizationRates,
+            nvmlInit,
+            nvmlShutdown,
+        )
+
+        nvmlInit()
+        try:
+            handle = nvmlDeviceGetHandleByIndex(0)
+            mem = nvmlDeviceGetMemoryInfo(handle)
+            util = nvmlDeviceGetUtilizationRates(handle)
+            metrics.setdefault("gpu_memory_used_bytes", mem.used)
+            metrics["gpu_memory_total_bytes"] = mem.total
+            metrics["gpu_utilization_pct"] = util.gpu
+        finally:
+            nvmlShutdown()
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    return metrics
+
+
 def dry_run_func(
     worker_cls: type[Worker],
     batch: int,
@@ -42,6 +101,7 @@ def dry_run_func(
     sender: PipeConnection,
     ingress: bool,
     shutdown_notify: Event,
+    metrics_sender: PipeConnection,
 ):
     """Dry run simulation function."""
     worker = worker_cls()
@@ -55,7 +115,21 @@ def dry_run_func(
     try:
         data = receiver.recv() if ingress else worker.deserialize(receiver.recv_bytes())
         logger.info("%s received %s", worker, data)
+
+        _try_reset_gpu_peak_memory()
+        cpu_before = time.process_time()
+
         data = worker.forward([data])[0] if batch > 1 else worker.forward(data)
+
+        cpu_after = time.process_time()
+        stage_metrics: Dict[str, Any] = {
+            "stage": worker_cls.__name__,
+            "cpu_time_seconds": cpu_after - cpu_before,
+            **_get_memory_metrics(),
+            **_get_gpu_metrics(),
+        }
+        metrics_sender.send(stage_metrics)
+
         logger.info("%s inference result: %s", worker, data)
         data = worker.serialize(data)
         sender.send_bytes(data)
@@ -82,6 +156,7 @@ class Pool:
         self.processes: List[SpawnProcess] = []
         self.sender_pipes: List[PipeConnection] = []
         self.receiver_pipes: List[PipeConnection] = []
+        self.metrics_receivers: List[PipeConnection] = []
 
     def new_pipe(self):
         """Create new pipe for dry run workers to communicate."""
@@ -98,6 +173,8 @@ class Pool:
 
         """
         self.new_pipe()
+        metrics_receiver, metrics_sender = self.process_context.Pipe(duplex=False)
+        self.metrics_receivers.append(metrics_receiver)
         coordinator = self.process_context.Process(
             target=dry_run_func,
             args=(
@@ -107,6 +184,7 @@ class Pool:
                 self.sender_pipes[-1],
                 init,
                 self.shutdown_notify,
+                metrics_sender,
             ),
             daemon=True,
         )
@@ -146,6 +224,22 @@ class Pool:
     def first_last_pipe(self):
         """Get first sender and last receiver pipes."""
         return self.sender_pipes[0], self.receiver_pipes[-1]
+
+    def collect_metrics(self, timeout: float = 5.0) -> List[Dict[str, Any]]:
+        """Collect metrics from all worker stages.
+
+        Args:
+            timeout: seconds to wait for each worker's metrics.
+
+        Returns:
+            List of per-stage metrics dicts.
+
+        """
+        results: List[Dict[str, Any]] = []
+        for receiver in self.metrics_receivers:
+            if receiver.poll(timeout):
+                results.append(receiver.recv())
+        return results
 
 
 class DryRunner:
@@ -249,13 +343,22 @@ class DryRunner:
 
         res = receiver.recv_bytes()
         duration = time.perf_counter() - start_time
-        logger.info(
-            "dry run result: %s",
-            json.dumps(
-                {
-                    "request": example,
-                    "result_size": len(res),
-                    "warmup_duration": duration,
-                }
-            ),
-        )
+
+        stage_metrics = pool.collect_metrics()
+        num_stages = len(runtimes)
+        if len(stage_metrics) < num_stages:
+            logger.warning(
+                "only received metrics from %d/%d stages"
+                " (some workers may have failed before reporting)",
+                len(stage_metrics),
+                num_stages,
+            )
+
+        result = {
+            "request": example,
+            "result_size": len(res),
+            "warmup_duration": duration,
+        }
+        if stage_metrics:
+            result["stage_metrics"] = stage_metrics
+        logger.info("dry run result: %s", json.dumps(result, default=str))

--- a/mosec/dry_run.py
+++ b/mosec/dry_run.py
@@ -70,7 +70,7 @@ def _get_gpu_metrics() -> Dict[str, Any]:
 
     try:
         # pylint: disable=import-outside-toplevel
-        from pynvml import (
+        from pynvml import (  # type: ignore[import-not-found]
             nvmlDeviceGetHandleByIndex,
             nvmlDeviceGetMemoryInfo,
             nvmlDeviceGetUtilizationRates,

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,176 @@
+# Copyright 2026 MOSEC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test dry run metrics collection."""
+
+from multiprocessing.context import SpawnContext
+from typing import List
+
+import pytest
+
+from mosec.dry_run import (
+    Pool,
+    _get_gpu_metrics,
+    _get_memory_metrics,
+    dry_run_func,
+)
+from mosec.runtime import Runtime
+from mosec.worker import Worker
+
+
+class EchoWorker(Worker):
+    def forward(self, data):
+        return data
+
+
+class BatchEchoWorker(Worker):
+    def forward(self, data: List[dict]) -> List[dict]:
+        return data
+
+
+@pytest.fixture
+def spawn_ctx():
+    ctx = SpawnContext()
+    shutdown_notify = ctx.Event()
+    return ctx, shutdown_notify
+
+
+@pytest.fixture
+def dry_run_pipes(spawn_ctx):
+    ctx, shutdown_notify = spawn_ctx
+    data_receiver, data_sender = ctx.Pipe(duplex=False)
+    result_receiver, result_sender = ctx.Pipe(duplex=False)
+    metrics_receiver, metrics_sender = ctx.Pipe(duplex=False)
+    return {
+        "ctx": ctx,
+        "shutdown_notify": shutdown_notify,
+        "data_receiver": data_receiver,
+        "data_sender": data_sender,
+        "result_receiver": result_receiver,
+        "result_sender": result_sender,
+        "metrics_receiver": metrics_receiver,
+        "metrics_sender": metrics_sender,
+    }
+
+
+def test_get_memory_metrics():
+    metrics = _get_memory_metrics()
+    assert "max_rss_bytes" in metrics
+    assert isinstance(metrics["max_rss_bytes"], int)
+    assert metrics["max_rss_bytes"] > 0
+
+
+def test_get_memory_metrics_unit():
+    metrics = _get_memory_metrics()
+    # should be > 1MB for any python process
+    assert metrics["max_rss_bytes"] > 1024 * 1024
+
+
+def test_get_gpu_metrics_no_gpu():
+    metrics = _get_gpu_metrics()
+    assert isinstance(metrics, dict)
+
+
+def test_dry_run_func_sends_metrics(dry_run_pipes):
+    p = dry_run_pipes
+    proc = p["ctx"].Process(
+        target=dry_run_func,
+        args=(
+            EchoWorker,
+            1,
+            p["data_receiver"],
+            p["result_sender"],
+            True,
+            p["shutdown_notify"],
+            p["metrics_sender"],
+        ),
+        daemon=True,
+    )
+    proc.start()
+    p["data_sender"].send({"x": 42})
+
+    assert p["result_receiver"].poll(timeout=10)
+    p["result_receiver"].recv_bytes()
+
+    assert p["metrics_receiver"].poll(timeout=5)
+    metrics = p["metrics_receiver"].recv()
+
+    assert metrics["stage"] == "EchoWorker"
+    assert metrics["cpu_time_seconds"] >= 0
+    assert metrics["max_rss_bytes"] > 0
+
+    p["shutdown_notify"].set()
+    proc.join(timeout=5)
+
+
+def test_dry_run_func_batch_worker(dry_run_pipes):
+    p = dry_run_pipes
+    proc = p["ctx"].Process(
+        target=dry_run_func,
+        args=(
+            BatchEchoWorker,
+            8,
+            p["data_receiver"],
+            p["result_sender"],
+            True,
+            p["shutdown_notify"],
+            p["metrics_sender"],
+        ),
+        daemon=True,
+    )
+    proc.start()
+    p["data_sender"].send({"x": 42})
+
+    assert p["result_receiver"].poll(timeout=10)
+    p["result_receiver"].recv_bytes()
+
+    assert p["metrics_receiver"].poll(timeout=5)
+    metrics = p["metrics_receiver"].recv()
+    assert metrics["stage"] == "BatchEchoWorker"
+
+    p["shutdown_notify"].set()
+    proc.join(timeout=5)
+
+
+def test_pool_collect_metrics(spawn_ctx):
+    ctx, shutdown_notify = spawn_ctx
+
+    pool = Pool(ctx, shutdown_notify)
+    pool.new_pipe()
+
+    runtime = Runtime(EchoWorker, num=1, max_batch_size=1, timeout=3.0)
+    pool.start_worker(runtime, init=True)
+
+    sender, receiver = pool.first_last_pipe()
+    sender.send({"x": 1})
+
+    assert receiver.poll(timeout=10)
+    receiver.recv_bytes()
+
+    metrics = pool.collect_metrics(timeout=5.0)
+    assert len(metrics) == 1
+    assert metrics[0]["stage"] == "EchoWorker"
+    assert metrics[0]["cpu_time_seconds"] >= 0
+    assert metrics[0]["max_rss_bytes"] > 0
+
+    shutdown_notify.set()
+    pool.wait_all()
+
+
+def test_pool_collect_metrics_timeout(spawn_ctx):
+    ctx, shutdown_notify = spawn_ctx
+    pool = Pool(ctx, shutdown_notify)
+
+    metrics = pool.collect_metrics(timeout=0.1)
+    assert metrics == []


### PR DESCRIPTION
Resolves #300

Collect per-stage CPU time, peak RSS, and GPU metrics (if torch/pynvml available) during `--dry-run`. Each worker sends metrics back via a dedicated pipe. Zero new dependencies.

GPU device hardcoded to index 0 for now.